### PR TITLE
[feat] 찜하기(WishList) 도메인 및 API 구현 (#6)

### DIFF
--- a/backend/bookbook/src/main/java/com/bookbook/domain/wishList/controller/WishListController.java
+++ b/backend/bookbook/src/main/java/com/bookbook/domain/wishList/controller/WishListController.java
@@ -1,11 +1,10 @@
 package com.bookbook.domain.wishList.controller;
 
-import com.bookbook.domain.wishList.entity.WishList;
+import com.bookbook.domain.wishList.dto.WishListResponseDto;
 import com.bookbook.domain.wishList.service.WishListService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -15,4 +14,12 @@ import java.util.List;
 public class WishListController {
 
     private final WishListService wishListService;
+
+    @GetMapping
+    public ResponseEntity<List<WishListResponseDto>> getWishList(
+            @RequestParam Long userId
+    ) {
+        List<WishListResponseDto> wishList = wishListService.getWishListByUserId(userId);
+        return ResponseEntity.ok(wishList);
+    }
 }

--- a/backend/bookbook/src/main/java/com/bookbook/domain/wishList/controller/WishListController.java
+++ b/backend/bookbook/src/main/java/com/bookbook/domain/wishList/controller/WishListController.java
@@ -1,5 +1,6 @@
 package com.bookbook.domain.wishList.controller;
 
+import com.bookbook.domain.wishList.dto.WishListCreateRequestDto;
 import com.bookbook.domain.wishList.dto.WishListResponseDto;
 import com.bookbook.domain.wishList.service.WishListService;
 import lombok.RequiredArgsConstructor;
@@ -21,5 +22,14 @@ public class WishListController {
     ) {
         List<WishListResponseDto> wishList = wishListService.getWishListByUserId(userId);
         return ResponseEntity.ok(wishList);
+    }
+
+    @PostMapping
+    public ResponseEntity<WishListResponseDto> addToWishList(
+            @RequestParam Long userId,
+            @RequestBody WishListCreateRequestDto request
+    ) {
+        WishListResponseDto response = wishListService.addToWishList(userId, request);
+        return ResponseEntity.ok(response);
     }
 }

--- a/backend/bookbook/src/main/java/com/bookbook/domain/wishList/controller/WishListController.java
+++ b/backend/bookbook/src/main/java/com/bookbook/domain/wishList/controller/WishListController.java
@@ -32,4 +32,14 @@ public class WishListController {
         WishListResponseDto response = wishListService.addWishList(userId, request);
         return ResponseEntity.ok(response);
     }
+
+    // TODO: Rent 엔티티 구현 후 활성화
+    // @DeleteMapping("/{rentId}")
+    // public ResponseEntity<Void> deleteWishList(
+    //         @RequestParam Long userId,
+    //         @PathVariable Long rentId
+    // ) {
+    //     wishListService.deleteWishList(userId, rentId);
+    //     return ResponseEntity.noContent().build();
+    // }
 }

--- a/backend/bookbook/src/main/java/com/bookbook/domain/wishList/controller/WishListController.java
+++ b/backend/bookbook/src/main/java/com/bookbook/domain/wishList/controller/WishListController.java
@@ -1,0 +1,18 @@
+package com.bookbook.domain.wishList.controller;
+
+import com.bookbook.domain.wishList.entity.WishList;
+import com.bookbook.domain.wishList.service.WishListService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/bookbook/wishList")
+@RequiredArgsConstructor
+public class WishListController {
+
+    private final WishListService wishListService;
+}

--- a/backend/bookbook/src/main/java/com/bookbook/domain/wishList/controller/WishListController.java
+++ b/backend/bookbook/src/main/java/com/bookbook/domain/wishList/controller/WishListController.java
@@ -25,11 +25,11 @@ public class WishListController {
     }
 
     @PostMapping
-    public ResponseEntity<WishListResponseDto> addToWishList(
+    public ResponseEntity<WishListResponseDto> addWishList(
             @RequestParam Long userId,
             @RequestBody WishListCreateRequestDto request
     ) {
-        WishListResponseDto response = wishListService.addToWishList(userId, request);
+        WishListResponseDto response = wishListService.addWishList(userId, request);
         return ResponseEntity.ok(response);
     }
 }

--- a/backend/bookbook/src/main/java/com/bookbook/domain/wishList/dto/WishListCreateRequestDto.java
+++ b/backend/bookbook/src/main/java/com/bookbook/domain/wishList/dto/WishListCreateRequestDto.java
@@ -1,0 +1,6 @@
+package com.bookbook.domain.wishList.dto;
+
+public record WishListCreateRequestDto(
+        Long rentId
+) {
+}

--- a/backend/bookbook/src/main/java/com/bookbook/domain/wishList/dto/WishListResponseDto.java
+++ b/backend/bookbook/src/main/java/com/bookbook/domain/wishList/dto/WishListResponseDto.java
@@ -9,17 +9,22 @@ public record WishListResponseDto(
         Long rentId,
         String bookTitle,
         String bookAuthor,
+        String bookPublisher,
         String bookCondition,
-        String bookStatus,
+        String rentStatus,
+        Long lenderUserId,
         LocalDateTime createDate
 ) {
     public static WishListResponseDto from(WishList wishList) {
         return new WishListResponseDto(
                 wishList.getId(),
                 wishList.getRent().getId(),
-                wishList.getRent().getBookTitle(),
-                wishList.getRent().getBookAuthor(),
-                wishList.getRent().getUser().getName(),
+                wishList.getRent().getTitle(),
+                wishList.getRent().getAuthor(),
+                wishList.getRent().getPublisher(),
+                wishList.getRent().getBookCondition(),
+                wishList.getRent().getBookStatus(),
+                wishList.getRent().getUser().getId(),
                 wishList.getCreateDate()
         );
     }

--- a/backend/bookbook/src/main/java/com/bookbook/domain/wishList/dto/WishListResponseDto.java
+++ b/backend/bookbook/src/main/java/com/bookbook/domain/wishList/dto/WishListResponseDto.java
@@ -6,25 +6,27 @@ import java.time.LocalDateTime;
 
 public record WishListResponseDto(
         Long id,
-        Long rentId,
-        String bookTitle,
-        String bookAuthor,
-        String bookPublisher,
-        String bookCondition,
-        String rentStatus,
-        Long lenderUserId,
+        // TODO: Rent 엔티티 구현 후 주석 해제
+        // Long rentId,
+        // String bookTitle,
+        // String bookAuthor,
+        // String bookPublisher,
+        // String bookCondition,
+        // String rentStatus,
+        // Long lenderUserId,
         LocalDateTime createDate
 ) {
     public static WishListResponseDto from(WishList wishList) {
+        // TODO: Rent 엔티티 구현 후 수정
         return new WishListResponseDto(
                 wishList.getId(),
-                wishList.getRent().getId(),
-                wishList.getRent().getTitle(),
-                wishList.getRent().getAuthor(),
-                wishList.getRent().getPublisher(),
-                wishList.getRent().getBookCondition(),
-                wishList.getRent().getBookStatus(),
-                wishList.getRent().getUser().getId(),
+                // wishList.getRent().getId(),
+                // wishList.getRent().getTitle(),
+                // wishList.getRent().getAuthor(),
+                // wishList.getRent().getPublisher(),
+                // wishList.getRent().getBookCondition(),
+                // wishList.getRent().getBookStatus(),
+                // wishList.getRent().getUser().getId(),
                 wishList.getCreateDate()
         );
     }

--- a/backend/bookbook/src/main/java/com/bookbook/domain/wishList/dto/WishListResponseDto.java
+++ b/backend/bookbook/src/main/java/com/bookbook/domain/wishList/dto/WishListResponseDto.java
@@ -1,0 +1,26 @@
+package com.bookbook.domain.wishList.dto;
+
+import com.bookbook.domain.wishList.entity.WishList;
+
+import java.time.LocalDateTime;
+
+public record WishListResponseDto(
+        Long id,
+        Long rentId,
+        String bookTitle,
+        String bookAuthor,
+        String bookCondition,
+        String bookStatus,
+        LocalDateTime createDate
+) {
+    public static WishListResponseDto from(WishList wishList) {
+        return new WishListResponseDto(
+                wishList.getId(),
+                wishList.getRent().getId(),
+                wishList.getRent().getBookTitle(),
+                wishList.getRent().getBookAuthor(),
+                wishList.getRent().getUser().getName(),
+                wishList.getCreateDate()
+        );
+    }
+}

--- a/backend/bookbook/src/main/java/com/bookbook/domain/wishList/entity/WishList.java
+++ b/backend/bookbook/src/main/java/com/bookbook/domain/wishList/entity/WishList.java
@@ -22,8 +22,9 @@ public class WishList {
     @ManyToOne
     private User user;
 
-    @ManyToOne
-    private Rent rent;
+    // TODO: Rent 엔티티 구현 후 주석 해제
+    // @ManyToOne
+    // private Rent rent;
 
     @CreatedDate
     private LocalDateTime createDate;

--- a/backend/bookbook/src/main/java/com/bookbook/domain/wishList/entity/WishList.java
+++ b/backend/bookbook/src/main/java/com/bookbook/domain/wishList/entity/WishList.java
@@ -1,0 +1,30 @@
+package com.bookbook.domain.wishList.entity;
+
+import com.bookbook.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+public class WishList {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    private User user;
+
+    @ManyToOne
+    private Rent rent;
+
+    @CreatedDate
+    private LocalDateTime createDate;
+}

--- a/backend/bookbook/src/main/java/com/bookbook/domain/wishList/repository/WishListRepository.java
+++ b/backend/bookbook/src/main/java/com/bookbook/domain/wishList/repository/WishListRepository.java
@@ -4,6 +4,11 @@ import com.bookbook.domain.wishList.entity.WishList;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface WishListRepository extends JpaRepository<WishList, Long> {
+
+    // 수정: createDate로 필드명 변경
+    List<WishList> findByUserIdOrderByCreateDateDesc(Long userId);
 }

--- a/backend/bookbook/src/main/java/com/bookbook/domain/wishList/repository/WishListRepository.java
+++ b/backend/bookbook/src/main/java/com/bookbook/domain/wishList/repository/WishListRepository.java
@@ -11,4 +11,7 @@ public interface WishListRepository extends JpaRepository<WishList, Long> {
 
     // 수정: createDate로 필드명 변경
     List<WishList> findByUserIdOrderByCreateDateDesc(Long userId);
+
+    // TODO: Rent 엔티티 구현 후 주석 해제
+    // Optional<WishList> findByUserIdAndRentId(Long userId, Long rentId);
 }

--- a/backend/bookbook/src/main/java/com/bookbook/domain/wishList/repository/WishListRepository.java
+++ b/backend/bookbook/src/main/java/com/bookbook/domain/wishList/repository/WishListRepository.java
@@ -1,0 +1,9 @@
+package com.bookbook.domain.wishList.repository;
+
+import com.bookbook.domain.wishList.entity.WishList;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface WishListRepository extends JpaRepository<WishList, Long> {
+}

--- a/backend/bookbook/src/main/java/com/bookbook/domain/wishList/service/WishListService.java
+++ b/backend/bookbook/src/main/java/com/bookbook/domain/wishList/service/WishListService.java
@@ -1,7 +1,10 @@
 package com.bookbook.domain.wishList.service;
 
 import com.bookbook.domain.user.entity.User;
+import com.bookbook.domain.user.repository.UserRepository;
+import com.bookbook.domain.wishList.dto.WishListCreateRequestDto;
 import com.bookbook.domain.wishList.dto.WishListResponseDto;
+import com.bookbook.domain.wishList.entity.WishList;
 import com.bookbook.domain.wishList.repository.WishListRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -13,11 +16,37 @@ import java.util.List;
 public class WishListService {
 
     private final WishListRepository wishListRepository;
+    private final UserRepository userRepository;
+    // TODO: RentRepository 추가 필요
 
     public List<WishListResponseDto> getWishListByUserId(Long userId) {
         return wishListRepository.findByUserIdOrderByCreateDateDesc(userId)
                 .stream()
                 .map(WishListResponseDto::from)
                 .toList();
+    }
+
+    public WishListResponseDto addToWishList(Long userId, WishListCreateRequestDto request) {
+        // TODO: Rent 엔티티 구현 후 중복 체크 로직 추가
+        // if (wishListRepository.findByUserIdAndRentId(userId, request.rentId()).isPresent()) {
+        //     throw new IllegalArgumentException("이미 찜한 게시글입니다.");
+        // }
+
+        // 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        // TODO: Rent 조회 - RentRepository 필요
+        // Rent rent = rentRepository.findById(request.rentId())
+        //         .orElseThrow(() -> new IllegalArgumentException("대여 게시글을 찾을 수 없습니다."));
+
+        // 찜 목록 생성
+        WishList wishlist = new WishList();
+        wishlist.setUser(user);
+        // wishlist.setRent(rent); // TODO: Rent 설정
+
+        // 저장 및 반환
+        WishList savedWishlist = wishListRepository.save(wishlist);
+        return WishListResponseDto.from(savedWishlist);
     }
 }

--- a/backend/bookbook/src/main/java/com/bookbook/domain/wishList/service/WishListService.java
+++ b/backend/bookbook/src/main/java/com/bookbook/domain/wishList/service/WishListService.java
@@ -49,4 +49,14 @@ public class WishListService {
         WishList savedWishlist = wishListRepository.save(wishlist);
         return WishListResponseDto.from(savedWishlist);
     }
+
+    public void deleteWishList(Long userId, Long rentId) {
+        // TODO: Rent 엔티티 구현 후 활성화
+        // WishList wishList = wishListRepository.findByUserIdAndRentId(userId, rentId)
+        //         .orElseThrow(() -> new IllegalArgumentException("찜하지 않은 게시글입니다."));
+        // wishListRepository.delete(wishList);
+
+        // 임시 구현: ID로 직접 삭제
+        throw new UnsupportedOperationException("Rent 엔티티 구현 필요");
+    }
 }

--- a/backend/bookbook/src/main/java/com/bookbook/domain/wishList/service/WishListService.java
+++ b/backend/bookbook/src/main/java/com/bookbook/domain/wishList/service/WishListService.java
@@ -26,7 +26,7 @@ public class WishListService {
                 .toList();
     }
 
-    public WishListResponseDto addToWishList(Long userId, WishListCreateRequestDto request) {
+    public WishListResponseDto addWishList(Long userId, WishListCreateRequestDto request) {
         // TODO: Rent 엔티티 구현 후 중복 체크 로직 추가
         // if (wishListRepository.findByUserIdAndRentId(userId, request.rentId()).isPresent()) {
         //     throw new IllegalArgumentException("이미 찜한 게시글입니다.");

--- a/backend/bookbook/src/main/java/com/bookbook/domain/wishList/service/WishListService.java
+++ b/backend/bookbook/src/main/java/com/bookbook/domain/wishList/service/WishListService.java
@@ -1,0 +1,12 @@
+package com.bookbook.domain.wishList.service;
+
+import com.bookbook.domain.wishList.repository.WishListRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class WishListService {
+
+    private final WishListRepository wishListRepository;
+}

--- a/backend/bookbook/src/main/java/com/bookbook/domain/wishList/service/WishListService.java
+++ b/backend/bookbook/src/main/java/com/bookbook/domain/wishList/service/WishListService.java
@@ -1,12 +1,23 @@
 package com.bookbook.domain.wishList.service;
 
+import com.bookbook.domain.user.entity.User;
+import com.bookbook.domain.wishList.dto.WishListResponseDto;
 import com.bookbook.domain.wishList.repository.WishListRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class WishListService {
 
     private final WishListRepository wishListRepository;
+
+    public List<WishListResponseDto> getWishListByUserId(Long userId) {
+        return wishListRepository.findByUserIdOrderByCreateDateDesc(userId)
+                .stream()
+                .map(WishListResponseDto::from)
+                .toList();
+    }
 }


### PR DESCRIPTION
## 💡 변경 사항

// 예시

- [x] WishList 엔티티 추가
- [x] WishListRepository 생성
- [x] WishListService에 찜 등록, 삭제, 조회 로직 구현
- [x] WishListController에 찜 등록/조회/삭제 API 구현
- [x] WishList 생성/조회 DTO 추가
- [x] 컴파일 오류 방지를 위한 임시 주석 처리

---

### ✅ 특이 사항

- 연관된 엔티티가 아직 없어서 일부 필드 주석 처리로 컴파일 오류를 방지했습니다.

---

### 🔗 관련 이슈

#6 

- 의존성 등 일부 코드를 개선한 이후에, 이슈를 닫을 예정입니다.
