### PR TITLE
[fix] 소셜 로그인 성공시 리다이렉트 되지 않던 문제 해결

### DIFF
--- a/backend/bookbook/build.gradle.kts
+++ b/backend/bookbook/build.gradle.kts
@@ -20,6 +20,7 @@ repositories {
 dependencies {
     // General
     developmentOnly("org.springframework.boot:spring-boot-devtools")
+    implementation("io.github.cdimascio:java-dotenv:5.2.2")
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-oauth2-client")

--- a/backend/bookbook/src/main/java/com/bookbook/BookbookApplication.java
+++ b/backend/bookbook/src/main/java/com/bookbook/BookbookApplication.java
@@ -1,5 +1,6 @@
 package com.bookbook;
 
+import io.github.cdimascio.dotenv.Dotenv;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
@@ -9,6 +10,8 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 public class BookbookApplication {
 
     public static void main(String[] args) {
+        Dotenv dotenv = Dotenv.load();
+        dotenv.entries().forEach(entry -> System.setProperty(entry.getKey(), entry.getValue()));
         SpringApplication.run(BookbookApplication.class, args);
     }
 

--- a/backend/bookbook/src/main/java/com/bookbook/domain/user/entity/User.java
+++ b/backend/bookbook/src/main/java/com/bookbook/domain/user/entity/User.java
@@ -35,7 +35,7 @@ public class User extends BaseEntity {
     @Column(name = "nickname", unique = true, nullable = false)
     private String nickname;
 
-    @Column(name = "email", unique = true, nullable = false)
+    @Column(name = "email", unique = true, nullable = true)
     private String email;
 
     @Column(name = "address", nullable = false)

--- a/backend/bookbook/src/main/java/com/bookbook/global/security/CustomOAuth2User.java
+++ b/backend/bookbook/src/main/java/com/bookbook/global/security/CustomOAuth2User.java
@@ -1,0 +1,58 @@
+package com.bookbook.global.security;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+
+import java.util.Collection;
+import java.util.Map;
+
+public class CustomOAuth2User extends DefaultOAuth2User {
+
+    private String username; // DB에 저장될 사용자 ID (ex: kakao_12345)
+    private String nickname;
+    private String email; // null 가능
+    private Long userId; // DB에 저장된 User 엔티티의 고유 ID
+    private boolean isNewUser; // 첫 로그인 여부
+
+    public CustomOAuth2User(Collection<? extends GrantedAuthority> authorities,
+                            Map<String, Object> attributes,
+                            String nameAttributeKey,
+                            String username,
+                            String nickname,
+                            String email,
+                            Long userId,
+                            boolean isNewUser) {
+        super(authorities, attributes, nameAttributeKey);
+        this.username = username;
+        this.nickname = nickname;
+        this.email = email;
+        this.userId = userId;
+        this.isNewUser = isNewUser;
+    }
+
+    // Getter 메서드들 (필요한 정보에 접근하기 위함)
+    @Override // DefaultOAuth2User의 getName()을 오버라이드하여 username 반환
+    public String getName() {
+        return this.username;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getNickname() {
+        return nickname;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public boolean isNewUser() {
+        return isNewUser;
+    }
+}

--- a/backend/bookbook/src/main/java/com/bookbook/global/security/CustomOAuth2UserService.java
+++ b/backend/bookbook/src/main/java/com/bookbook/global/security/CustomOAuth2UserService.java
@@ -4,7 +4,6 @@ import com.bookbook.domain.user.entity.User;
 import com.bookbook.domain.user.enums.Role;
 import com.bookbook.domain.user.enums.UserStatus;
 import com.bookbook.domain.user.repository.UserRepository;
-import com.bookbook.domain.user.service.UserService;
 import com.bookbook.global.util.NicknameGenerator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -13,7 +12,6 @@ import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserServ
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
-import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -42,31 +40,41 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
 
         User user;
         String username = registrationId + "_" + attributes.id();
+        boolean isNewUser = false; // 첫 로그인 여부를 저장할 플래그
 
         Optional<User> existingUser = userRepository.findByUsername(username);
 
         if(existingUser.isPresent()) {
             user = existingUser.get();
+            user.changeNickname(attributes.getNickname());
+            userRepository.save(user); // 변경된 내용 저장
         } else {
-            String uniqueNickname = nicknameGenerator.generateUniqueNickname(attributes.getNickname()); // 변경
+            // 새 사용자일 경우
+            String uniqueNickname = nicknameGenerator.generateUniqueNickname(attributes.getNickname());
             user = User.builder()
                     .username(username)
-                    .email(attributes.email())
+                    .email(attributes.email()) // email은 null일 수 있음
                     .nickname(uniqueNickname)
                     .address("기본 주소")
-                    .password(passwordEncoder.encode(UUID.randomUUID().toString()))
+                    .password(passwordEncoder.encode(UUID.randomUUID().toString())) // 임시 비밀번호
                     .rating(0.0f)
                     .role(Role.USER)
                     .userStatus(UserStatus.ACTIVE)
                     .build();
             userRepository.save(user);
+            isNewUser = true; // 새로운 사용자임을 표시
         }
 
-        return new DefaultOAuth2User(
+        // DefaultOAuth2User 대신 CustomOAuth2User 객체를 반환
+        return new CustomOAuth2User(
                 Collections.singleton(new SimpleGrantedAuthority(user.getRole().name())),
-                oAuth2User.getAttributes(),
-                userNameAttributeName
+                oAuth2User.getAttributes(), // OAuth2 provider로부터 받은 원본 속성
+                userNameAttributeName,
+                user.getUsername(), // DB에 저장된 사용자 ID (ex: kakao_12345)
+                user.getNickname(), // DB에 저장된 닉네임
+                user.getEmail(),    // DB에 저장된 이메일 (null 가능)
+                user.getId(),       // DB에 저장된 User 엔티티의 고유 ID
+                isNewUser           // 첫 로그인 여부 전달
         );
     }
-
 }

--- a/backend/bookbook/src/main/java/com/bookbook/global/security/LoginSuccessHandler.java
+++ b/backend/bookbook/src/main/java/com/bookbook/global/security/LoginSuccessHandler.java
@@ -22,7 +22,7 @@ public class LoginSuccessHandler implements AuthenticationSuccessHandler {
         // 첫 로그인 여부 확인
         if (oauth2User.isNewUser()) {
             // 첫 로그인인 경우 회원가입 정보 입력 페이지로 리다이렉트
-            response.sendRedirect("http://localhost:3000/bookbook/signup");
+            response.sendRedirect("http://localhost:3000/bookbook/user/signup");
         } else {
             // 첫 로그인이 아닌 경우 메인 페이지로 리다이렉트
             response.sendRedirect("http://localhost:3000/bookbook");

--- a/backend/bookbook/src/main/java/com/bookbook/global/security/LoginSuccessHandler.java
+++ b/backend/bookbook/src/main/java/com/bookbook/global/security/LoginSuccessHandler.java
@@ -1,0 +1,31 @@
+package com.bookbook.global.security; // 적절한 패키지로 변경하세요
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component // 스프링 빈으로 등록하기 위함
+public class LoginSuccessHandler implements AuthenticationSuccessHandler {
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+                                        Authentication authentication) throws IOException, ServletException {
+
+        // 로그인한 사용자 정보 가져오기
+        CustomOAuth2User oauth2User = (CustomOAuth2User) authentication.getPrincipal();
+
+        // 첫 로그인 여부 확인
+        if (oauth2User.isNewUser()) {
+            // 첫 로그인인 경우 회원가입 정보 입력 페이지로 리다이렉트
+            response.sendRedirect("http://localhost:3000/bookbook/signup");
+        } else {
+            // 첫 로그인이 아닌 경우 메인 페이지로 리다이렉트
+            response.sendRedirect("http://localhost:3000/bookbook");
+        }
+    }
+}

--- a/backend/bookbook/src/main/java/com/bookbook/global/security/OAuth2UserAttributes.java
+++ b/backend/bookbook/src/main/java/com/bookbook/global/security/OAuth2UserAttributes.java
@@ -47,15 +47,19 @@ public record OAuth2UserAttributes(
         Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
         Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
 
-        String email = (String) kakaoAccount.get("email");
+        // 카카오는 이메일 정보는 받아올 수 없으므로 null 또는 빈 문자열을 사용합니다.
+        String email = null;
+
         String nickname = (String) profile.get("nickname");
+
+        String id = String.valueOf(attributes.get("id"));
 
         return new OAuth2UserAttributes(
                 attributes,
                 userNameAttributeName,
                 nickname,
-                email,
-                String.valueOf(attributes.get(userNameAttributeName))
+                email, // 이메일 필드에 null 또는 빈 문자열 전달
+                id
         );
     }
 

--- a/backend/bookbook/src/main/java/com/bookbook/global/security/securityConfig.java
+++ b/backend/bookbook/src/main/java/com/bookbook/global/security/securityConfig.java
@@ -6,8 +6,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
-import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
@@ -22,7 +20,7 @@ public class securityConfig {
     private final CustomOAuth2UserService customOAuth2UserService;
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain securityFilterChain(HttpSecurity http, LoginSuccessHandler loginSuccessHandler) throws Exception {
         http
                 .csrf(csrf -> csrf.disable()) // REST API에서는 CSRF 비활성화 (토큰 기반 인증 시)
                 .authorizeHttpRequests(authorize -> authorize
@@ -37,20 +35,12 @@ public class securityConfig {
                         .userInfoEndpoint(userInfo -> userInfo
                                 .userService(customOAuth2UserService) // 사용자 정보를 가져온 후 처리할 서비스 지정
                         )
-                        .successHandler(oauth2AuthenticationSuccessHandler()) // OAuth2 로그인 성공 후 처리할 핸들러 지정
+                        .successHandler(loginSuccessHandler) // OAuth2 로그인 성공 후 처리할 핸들러 지정
                 )
                 .headers(headers -> headers.frameOptions(frameOptions -> frameOptions.sameOrigin())); // H2 Console 사용을 위함
         return http.build();
     }
 
-    // OAuth2 로그인 성공 후 리다이렉트할 URL을 설정하는 핸들러
-    @Bean
-    public AuthenticationSuccessHandler oauth2AuthenticationSuccessHandler() {
-        SimpleUrlAuthenticationSuccessHandler handler = new SimpleUrlAuthenticationSuccessHandler();
-        handler.setDefaultTargetUrl("/"); // 로그인 성공 후 리다이렉트할 URL 설정
-        handler.setAlwaysUseDefaultTargetUrl(true);
-        return handler;
-    }
     // --- CORS 설정을 위한 Bean을 추가합니다 ---
     @Bean
     public UrlBasedCorsConfigurationSource corsConfigurationSource() {

--- a/backend/bookbook/src/main/java/com/bookbook/global/security/securityConfig.java
+++ b/backend/bookbook/src/main/java/com/bookbook/global/security/securityConfig.java
@@ -5,13 +5,12 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
 import java.util.Arrays;
 import java.util.List;
 
@@ -28,7 +27,7 @@ public class securityConfig {
                 .csrf(csrf -> csrf.disable()) // REST API에서는 CSRF 비활성화 (토큰 기반 인증 시)
                 .authorizeHttpRequests(authorize -> authorize
                         // 로그인 관련 경로는 모두 허용
-                        .requestMatchers("/api/admin/login", "/bookbook/users/login/dev", "/bookbook/users/social/callback", "/login/**", "/bookbook/home").permitAll()
+                        .requestMatchers("/api/admin/login", "api/v1/bookbook/users/login/dev", "api/v1/bookbook/users/social/callback", "/login/**", "/bookbook/home", "/api/v1/bookbook/login/oauth2/code/**").permitAll()
                         .requestMatchers("/favicon.ico").permitAll() // 파비콘 접근 허용
                         .requestMatchers("/h2-console/**").permitAll()
                         .requestMatchers("/bookbook/rent/create").permitAll() // Rent 페이지 생성은 인증 필요, (임시)               

--- a/backend/bookbook/src/main/resources/application.yml
+++ b/backend/bookbook/src/main/resources/application.yml
@@ -28,10 +28,10 @@ spring:
           kakao:
             client-id: ${KAKAO_API_KEY}
             client-secret: ${KAKAO_CLIENT_SECRET}
-            scope: profile, account_email
+            scope: profile_nickname
             redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
             client-name: KAKAO
-            client-authentication-method: post
+            client-authentication-method: client_secret_post
             authorization-grant-type: authorization_code
           naver:
             client-id: ${NAVER_API_KEY}

--- a/backend/bookbook/src/main/resources/application.yml
+++ b/backend/bookbook/src/main/resources/application.yml
@@ -29,7 +29,7 @@ spring:
             client-id: ${KAKAO_API_KEY}
             client-secret: ${KAKAO_CLIENT_SECRET}
             scope: profile, account_email
-            redirect-uri: "http://localhost:8080/api/v1/bookbook/login/oauth2/code/kakao"
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
             client-name: KAKAO
             client-authentication-method: post
             authorization-grant-type: authorization_code
@@ -37,14 +37,14 @@ spring:
             client-id: ${NAVER_API_KEY}
             client-secret: ${NAVER_CLIENT_SECRET}
             scope: profile
-            redirect-uri: "http://localhost:8080/api/v1/bookbook/login/oauth2/code/naver"
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
             client-name: Naver
             authorization-grant-type: authorization_code
           google:
             client-id: ${GOOGLE_API_KEY}
             client-secret: ${GOOGLE_CLIENT_SECRET}
             scope: profile, email
-            redirect-uri: "http://localhost:8080/api/v1/bookbook/login/oauth2/code/google"
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
             client-name: Google
             authorization-grant-type: authorization_code
         provider:


### PR DESCRIPTION
## 💡 변경 사항

// 예시

- [x] 소셜 로그인 성공 (데이터 베이스에 잘 들어감)
- [x] 첫 로그인 시 회원가입 페이지로 이동될 수 있도록

---

### ✅ 특이 사항
카카오는 이메일을 받아오려면 앱 심사를 해야되서 잠시 이메일을 nullable 로 지정해 놓았지만 
필드자체를 제거해도 되는지 의논을 해봐야 할 듯(굳이 필요없다 느껴지면)

- 코드에서 특별히 설명해야 할 부분 (주석 등으로 드러나지 않는 부분)
- 코드 리뷰를 특별히 요청하고 싶은 부분

---

### 🔗 관련 이슈

closed #55 (#닫고싶은 이슈번호)
