### PR TITLE
[feat] 찜 목록의 전체 api 수정 및 사용자 ID를 받는 방식 변경

### DIFF
--- a/backend/.idea/.gitignore
+++ b/backend/.idea/.gitignore
@@ -1,0 +1,10 @@
+# 디폴트 무시된 파일
+/shelf/
+/workspace.xml
+# 에디터 기반 HTTP 클라이언트 요청
+/httpRequests/
+# 환경에 따라 달라지는 Maven 홈 디렉터리
+/mavenHomeManager.xml
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/backend/.idea/backend.iml
+++ b/backend/.idea/backend.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/backend/.idea/misc.xml
+++ b/backend/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="21" project-jdk-type="JavaSDK">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/backend/.idea/modules.xml
+++ b/backend/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/backend.iml" filepath="$PROJECT_DIR$/.idea/backend.iml" />
+    </modules>
+  </component>
+</project>

--- a/backend/.idea/vcs.xml
+++ b/backend/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
+  </component>
+</project>

--- a/backend/bookbook/src/main/java/com/bookbook/domain/lendList/controller/LendListController.java
+++ b/backend/bookbook/src/main/java/com/bookbook/domain/lendList/controller/LendListController.java
@@ -1,0 +1,47 @@
+package com.bookbook.domain.lendList.controller;
+
+import com.bookbook.domain.lendList.dto.LendListResponseDto;
+import com.bookbook.domain.lendList.service.LendListService;
+import com.bookbook.global.rsdata.RsData;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/user/{userId}/lendlist")
+@RequiredArgsConstructor
+public class LendListController {
+    
+    private final LendListService lendListService;
+    
+    @GetMapping
+    public ResponseEntity<RsData<Page<LendListResponseDto>>> getLendListByUserId(
+            @PathVariable Long userId,
+            @PageableDefault(size = 10, sort = "createAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        
+        Page<LendListResponseDto> lendList = lendListService.getLendListByUserId(userId, pageable);
+        return ResponseEntity.ok(RsData.of("S-1", "사용자의 대여 게시물 목록 조회 성공", lendList));
+    }
+    
+    @GetMapping("/all")
+    public ResponseEntity<RsData<List<LendListResponseDto>>> getAllLendListByUserId(@PathVariable Long userId) {
+        List<LendListResponseDto> lendList = lendListService.getAllLendListByUserId(userId);
+        return ResponseEntity.ok(RsData.of("S-1", "사용자의 전체 대여 게시물 목록 조회 성공", lendList));
+    }
+    
+    @GetMapping("/status/{status}")
+    public ResponseEntity<RsData<Page<LendListResponseDto>>> getLendListByUserIdAndStatus(
+            @PathVariable Long userId,
+            @PathVariable String status,
+            @PageableDefault(size = 10, sort = "createAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        
+        Page<LendListResponseDto> lendList = lendListService.getLendListByUserIdAndStatus(userId, status, pageable);
+        return ResponseEntity.ok(RsData.of("S-1", "사용자의 상태별 대여 게시물 목록 조회 성공", lendList));
+    }
+}

--- a/backend/bookbook/src/main/java/com/bookbook/domain/lendList/dto/LendListResponseDto.java
+++ b/backend/bookbook/src/main/java/com/bookbook/domain/lendList/dto/LendListResponseDto.java
@@ -1,0 +1,46 @@
+package com.bookbook.domain.lendList.dto;
+
+import com.bookbook.domain.rent.entity.Rent;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class LendListResponseDto {
+    
+    private Long id;
+    private Long lenderUserId;
+    private String title;
+    private String bookTitle;
+    private String author;
+    private String publisher;
+    private String category;
+    private String bookCondition;
+    private String bookImage;
+    private String address;
+    private String contents;
+    private String rentStatus;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    
+    public static LendListResponseDto from(Rent rent) {
+        return LendListResponseDto.builder()
+                .id(rent.getId())
+                .lenderUserId(rent.getLender_user_id())
+                .title(rent.getTitle())
+                .bookTitle(rent.getBookTitle())
+                .author(rent.getAuthor())
+                .publisher(rent.getPublisher())
+                .category(rent.getCategory())
+                .bookCondition(rent.getBookCondition())
+                .bookImage(rent.getBookImage())
+                .address(rent.getAddress())
+                .contents(rent.getContents())
+                .rentStatus(rent.getRent_status())
+                .createdAt(rent.getCreateAt())
+                .updatedAt(rent.getUpdateAt())
+                .build();
+    }
+}

--- a/backend/bookbook/src/main/java/com/bookbook/domain/lendList/repository/LendListRepository.java
+++ b/backend/bookbook/src/main/java/com/bookbook/domain/lendList/repository/LendListRepository.java
@@ -1,0 +1,19 @@
+package com.bookbook.domain.lendList.repository;
+
+import com.bookbook.domain.rent.entity.Rent;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface LendListRepository extends JpaRepository<Rent, Long> {
+    
+    Page<Rent> findByLenderUserId(Long lenderUserId, Pageable pageable);
+    
+    List<Rent> findByLenderUserId(Long lenderUserId);
+    
+    Page<Rent> findByLenderUserIdAndRentStatus(Long lenderUserId, String rentStatus, Pageable pageable);
+}

--- a/backend/bookbook/src/main/java/com/bookbook/domain/lendList/service/LendListService.java
+++ b/backend/bookbook/src/main/java/com/bookbook/domain/lendList/service/LendListService.java
@@ -1,0 +1,38 @@
+package com.bookbook.domain.lendList.service;
+
+import com.bookbook.domain.lendList.dto.LendListResponseDto;
+import com.bookbook.domain.lendList.repository.LendListRepository;
+import com.bookbook.domain.rent.entity.Rent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class LendListService {
+    
+    private final LendListRepository lendListRepository;
+    
+    public Page<LendListResponseDto> getLendListByUserId(Long userId, Pageable pageable) {
+        Page<Rent> rentPage = lendListRepository.findByLenderUserId(userId, pageable);
+        return rentPage.map(LendListResponseDto::from);
+    }
+    
+    public List<LendListResponseDto> getAllLendListByUserId(Long userId) {
+        List<Rent> rentList = lendListRepository.findByLenderUserId(userId);
+        return rentList.stream()
+                .map(LendListResponseDto::from)
+                .collect(Collectors.toList());
+    }
+    
+    public Page<LendListResponseDto> getLendListByUserIdAndStatus(Long userId, String status, Pageable pageable) {
+        Page<Rent> rentPage = lendListRepository.findByLenderUserIdAndRentStatus(userId, status, pageable);
+        return rentPage.map(LendListResponseDto::from);
+    }
+}

--- a/backend/bookbook/src/main/java/com/bookbook/domain/wishList/controller/WishListController.java
+++ b/backend/bookbook/src/main/java/com/bookbook/domain/wishList/controller/WishListController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/v1/bookbook/wishlists")
+@RequestMapping("/api/v1/user/{userId}/wishlist")
 @RequiredArgsConstructor
 public class WishListController {
 
@@ -18,7 +18,7 @@ public class WishListController {
 
     @GetMapping
     public ResponseEntity<List<WishListResponseDto>> getWishList(
-            @RequestParam Long userId
+            @PathVariable Long userId
     ) {
         List<WishListResponseDto> wishList = wishListService.getWishListByUserId(userId);
         return ResponseEntity.ok(wishList);
@@ -26,7 +26,7 @@ public class WishListController {
 
     @PostMapping
     public ResponseEntity<WishListResponseDto> addWishList(
-            @RequestParam Long userId,
+            @PathVariable Long userId,
             @RequestBody WishListCreateRequestDto request
     ) {
         WishListResponseDto response = wishListService.addWishList(userId, request);
@@ -35,7 +35,7 @@ public class WishListController {
 
     @DeleteMapping("/{rentId}")
     public ResponseEntity<Void> deleteWishList(
-            @RequestParam Long userId,
+            @PathVariable Long userId,
             @PathVariable Integer rentId
     ) {
         wishListService.deleteWishList(userId, rentId);


### PR DESCRIPTION
## 💡 변경 사항

- 찜 목록의 전체 api 수정
- query param에서 path param으로 UserId를 받는 방식을 수정

---

### ✅ 특이 사항

- 찜 목록의 전체 api 수정하게 되면서, query param에서 path param으로 UserId를 받는 방식을 수정했습니다.

---

### 🔗 관련 이슈

#6
