### PR TITLE
[refactor] 찜 목록의 전체 API URL수정 및 사용자 ID를 받는 방식 변경

### DIFF
--- a/backend/bookbook/src/main/java/com/bookbook/domain/wishList/controller/WishListController.java
+++ b/backend/bookbook/src/main/java/com/bookbook/domain/wishList/controller/WishListController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/v1/bookbook/wishlists")
+@RequestMapping("/api/v1/user/{userId}/wishlist")
 @RequiredArgsConstructor
 public class WishListController {
 
@@ -18,7 +18,7 @@ public class WishListController {
 
     @GetMapping
     public ResponseEntity<List<WishListResponseDto>> getWishList(
-            @RequestParam Long userId
+            @PathVariable Long userId
     ) {
         List<WishListResponseDto> wishList = wishListService.getWishListByUserId(userId);
         return ResponseEntity.ok(wishList);
@@ -26,7 +26,7 @@ public class WishListController {
 
     @PostMapping
     public ResponseEntity<WishListResponseDto> addWishList(
-            @RequestParam Long userId,
+            @PathVariable Long userId,
             @RequestBody WishListCreateRequestDto request
     ) {
         WishListResponseDto response = wishListService.addWishList(userId, request);
@@ -35,7 +35,7 @@ public class WishListController {
 
     @DeleteMapping("/{rentId}")
     public ResponseEntity<Void> deleteWishList(
-            @RequestParam Long userId,
+            @PathVariable Long userId,
             @PathVariable Integer rentId
     ) {
         wishListService.deleteWishList(userId, rentId);


### PR DESCRIPTION
## 💡 변경 사항

- 찜 목록의 전체 api 수정
- query param에서 path param으로 UserId를 받는 방식을 수정

---

### ✅ 특이 사항

- 찜 목록의 전체 api 수정하게 되면서, query param에서 path param으로 UserId를 받는 방식을 수정했습니다.

---

### 🔗 관련 이슈

#6
