### PR TITLE
[feat] 등록한 도서 내역 도메인 및 API 구현 (#51)

### DIFF
--- a/backend/bookbook/src/main/java/com/bookbook/domain/lendList/controller/LendListController.java
+++ b/backend/bookbook/src/main/java/com/bookbook/domain/lendList/controller/LendListController.java
@@ -1,0 +1,29 @@
+package com.bookbook.domain.lendList.controller;
+
+import com.bookbook.domain.lendList.dto.LendListResponseDto;
+import com.bookbook.domain.lendList.service.LendListService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+
+@RestController
+@RequestMapping("/api/v1/user/{userId}/lendlist")
+@RequiredArgsConstructor
+public class LendListController {
+    
+    private final LendListService lendListService;
+    
+    @GetMapping
+    public ResponseEntity<Page<LendListResponseDto>> getLendListByUserId(
+            @PathVariable Long userId,
+            @PageableDefault(size = 10, sort = "createAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        
+        Page<LendListResponseDto> lendList = lendListService.getLendListByUserId(userId, pageable);
+        return ResponseEntity.ok(lendList);
+    }
+}

--- a/backend/bookbook/src/main/java/com/bookbook/domain/lendList/dto/LendListResponseDto.java
+++ b/backend/bookbook/src/main/java/com/bookbook/domain/lendList/dto/LendListResponseDto.java
@@ -1,0 +1,40 @@
+package com.bookbook.domain.lendList.dto;
+
+import com.bookbook.domain.rent.entity.Rent;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class LendListResponseDto {
+    
+    private Integer id;
+    private Long lenderUserId;
+    private String title;
+    private String bookTitle;
+    private String author;
+    private String publisher;
+    private String bookCondition;
+    private String bookImage;
+    private String rentStatus;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static LendListResponseDto from(Rent rent) {
+        return LendListResponseDto.builder()
+                .id(rent.getId())
+                .lenderUserId(rent.getLender_user_id())
+                .title(rent.getTitle())
+                .bookTitle(rent.getBookTitle())
+                .author(rent.getAuthor())
+                .publisher(rent.getPublisher())
+                .bookCondition(rent.getBookCondition())
+                .bookImage(rent.getBookImage())
+                .rentStatus(rent.getRent_status())
+                .createdAt(rent.getCreatedDate())
+                .updatedAt(rent.getModifiedDate())
+                .build();
+    }
+}

--- a/backend/bookbook/src/main/java/com/bookbook/domain/lendList/repository/LendListRepository.java
+++ b/backend/bookbook/src/main/java/com/bookbook/domain/lendList/repository/LendListRepository.java
@@ -1,0 +1,13 @@
+package com.bookbook.domain.lendList.repository;
+
+import com.bookbook.domain.rent.entity.Rent;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LendListRepository extends JpaRepository<Rent, Long> {
+    
+    Page<Rent> findByLenderUserId(Long lenderUserId, Pageable pageable);
+}

--- a/backend/bookbook/src/main/java/com/bookbook/domain/lendList/service/LendListService.java
+++ b/backend/bookbook/src/main/java/com/bookbook/domain/lendList/service/LendListService.java
@@ -1,0 +1,24 @@
+package com.bookbook.domain.lendList.service;
+
+import com.bookbook.domain.lendList.dto.LendListResponseDto;
+import com.bookbook.domain.lendList.repository.LendListRepository;
+import com.bookbook.domain.rent.entity.Rent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class LendListService {
+    
+    private final LendListRepository lendListRepository;
+    
+    public Page<LendListResponseDto> getLendListByUserId(Long userId, Pageable pageable) {
+        Page<Rent> rentPage = lendListRepository.findByLenderUserId(userId, pageable);
+        return rentPage.map(LendListResponseDto::from);
+    }
+}


### PR DESCRIPTION
## 💡 변경 사항

- [x] LentList 조회 DTO 추가
- [x] LentListRepository 생성
- [x] LentListService에 찜 등록, 삭제, 조회 로직 구현
- [x] LentListController에 찜 등록/조회/삭제 API 구현

---

### ✅ 특이 사항

- 등록한 도서 내역 관련 도메인을 추가했습니다.
- '대여한 도서 내역'이 아직 개발 전이라서, 이과 관련하여 연동되어야 할 부분들이 구현 전입니다.

---

### 🔗 관련 이슈

#51 

- 해당 이슈는 '대여한 도서 내역'과 연동 후에 닫을 예정입니다.
