### PR TITLE
[feat] 대여한 도서 내역 관련 도메인 추가 및 구현 (#68)

### DIFF
--- a/backend/bookbook/src/main/java/com/bookbook/domain/rentList/controller/RentListController.java
+++ b/backend/bookbook/src/main/java/com/bookbook/domain/rentList/controller/RentListController.java
@@ -1,0 +1,32 @@
+package com.bookbook.domain.rentList.controller;
+
+import com.bookbook.domain.rentList.dto.RentListCreateRequestDto;
+import com.bookbook.domain.rentList.dto.RentListResponseDto;
+import com.bookbook.domain.rentList.service.RentListService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/user/{borrowerUserId}/rentlist")
+@RequiredArgsConstructor
+public class RentListController {
+    
+    private final RentListService rentListService;
+    
+    @GetMapping
+    public ResponseEntity<List<RentListResponseDto>> getRentListByUserId(@PathVariable Long borrowerUserId) {
+        List<RentListResponseDto> rentList = rentListService.getRentListByUserId(borrowerUserId);
+        return ResponseEntity.ok(rentList);
+    }
+    
+    @PostMapping
+    public ResponseEntity<RentListResponseDto> createRentList(
+            @PathVariable Long borrowerUserId,
+            @RequestBody RentListCreateRequestDto request) {
+        RentListResponseDto response = rentListService.createRentList(borrowerUserId, request);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/backend/bookbook/src/main/java/com/bookbook/domain/rentList/dto/RentListCreateRequestDto.java
+++ b/backend/bookbook/src/main/java/com/bookbook/domain/rentList/dto/RentListCreateRequestDto.java
@@ -1,0 +1,14 @@
+package com.bookbook.domain.rentList.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class RentListCreateRequestDto {
+    
+    private LocalDateTime loanDate;
+    private Integer rentId;
+}

--- a/backend/bookbook/src/main/java/com/bookbook/domain/rentList/dto/RentListResponseDto.java
+++ b/backend/bookbook/src/main/java/com/bookbook/domain/rentList/dto/RentListResponseDto.java
@@ -1,0 +1,32 @@
+package com.bookbook.domain.rentList.dto;
+
+import com.bookbook.domain.rentList.entity.RentList;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class RentListResponseDto {
+    
+    private Integer id;
+    private LocalDateTime loanDate;
+    private LocalDateTime returnDate;
+    private Long borrowerUserId;
+    private Integer rentId;
+    private LocalDateTime createdDate;
+    private LocalDateTime modifiedDate;
+    
+    public static RentListResponseDto from(RentList rentList) {
+        return new RentListResponseDto(
+                rentList.getId(),
+                rentList.getLoanDate(),
+                rentList.getReturnDate(),
+                rentList.getBorrowerUser() != null ? rentList.getBorrowerUser().getId() : null,
+                rentList.getRent() != null ? rentList.getRent().getId() : null,
+                rentList.getCreatedDate(),
+                rentList.getModifiedDate()
+        );
+    }
+}

--- a/backend/bookbook/src/main/java/com/bookbook/domain/rentList/entity/RentList.java
+++ b/backend/bookbook/src/main/java/com/bookbook/domain/rentList/entity/RentList.java
@@ -1,0 +1,27 @@
+package com.bookbook.domain.rentList.entity;
+
+import com.bookbook.domain.rent.entity.Rent;
+import com.bookbook.domain.user.entity.User;
+import com.bookbook.global.jpa.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+public class RentList extends BaseEntity {
+    
+    private LocalDateTime loanDate;
+    private LocalDateTime returnDate;
+    
+    @ManyToOne
+    private User borrowerUser;
+    
+    @ManyToOne
+    private Rent rent;
+}

--- a/backend/bookbook/src/main/java/com/bookbook/domain/rentList/repository/RentListRepository.java
+++ b/backend/bookbook/src/main/java/com/bookbook/domain/rentList/repository/RentListRepository.java
@@ -1,0 +1,13 @@
+package com.bookbook.domain.rentList.repository;
+
+import com.bookbook.domain.rentList.entity.RentList;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface RentListRepository extends JpaRepository<RentList, Integer> {
+    
+    List<RentList> findByBorrowerUserId(Long borrowerUserId);
+}

--- a/backend/bookbook/src/main/java/com/bookbook/domain/rentList/service/RentListService.java
+++ b/backend/bookbook/src/main/java/com/bookbook/domain/rentList/service/RentListService.java
@@ -1,0 +1,55 @@
+package com.bookbook.domain.rentList.service;
+
+import com.bookbook.domain.rent.entity.Rent;
+import com.bookbook.domain.rent.repository.RentRepository;
+import com.bookbook.domain.rentList.dto.RentListCreateRequestDto;
+import com.bookbook.domain.rentList.dto.RentListResponseDto;
+import com.bookbook.domain.rentList.entity.RentList;
+import com.bookbook.domain.rentList.repository.RentListRepository;
+import com.bookbook.domain.user.entity.User;
+import com.bookbook.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RentListService {
+    
+    private final RentListRepository rentListRepository;
+    private final UserRepository userRepository;
+    private final RentRepository rentRepository;
+    
+    
+    public List<RentListResponseDto> getRentListByUserId(Long borrowerUserId) {
+        return rentListRepository.findByBorrowerUserId(borrowerUserId).stream()
+                .map(RentListResponseDto::from)
+                .collect(Collectors.toList());
+    }
+    
+    @Transactional
+    public RentListResponseDto createRentList(Long borrowerUserId, RentListCreateRequestDto request) {
+        // User 엔티티 조회; 로그인하지 않은 사용자, 정지된 사용자 등
+        User borrowerUser = userRepository.findById(borrowerUserId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다. userId: " + borrowerUserId));
+        
+        // Rent 엔티티 조회
+        Rent rent = rentRepository.findById(request.getRentId())
+                .orElseThrow(() -> new IllegalArgumentException("대여 게시글을 찾을 수 없습니다. rentId: " + request.getRentId()));
+        
+        RentList rentList = new RentList();
+        rentList.setLoanDate(request.getLoanDate());
+        // returnDate는 loanDate로부터 14일 후로 자동 계산
+        rentList.setReturnDate(request.getLoanDate().plusDays(14));
+        // 연관관계 설정
+        rentList.setBorrowerUser(borrowerUser);
+        rentList.setRent(rent);
+        
+        RentList savedRentList = rentListRepository.save(rentList);
+        return RentListResponseDto.from(savedRentList);
+    }
+}


### PR DESCRIPTION
## 💡 변경 사항

- [x] RentList 엔티티 추가
- [x] RentList 조회 DTO 추가
- [x] RentList 등록 DTO 추가
- [x] RentListRepository 생성
- [x] RentListService에 등록, 조회 로직 구현
- [x] RentListController에 등록/조회 API 구현

---

### ✅ 특이 사항

- 대여한 도서 내역 관련 도메인을 추가했습니다.
- 리뷰쓰기 기능이 아직 구현되지 않았습니다.

---

### 🔗 관련 이슈

#68 

- 해당 이슈는 아직 개발 중이므로 추후에 닫을 예정입니다.
