### PR TITLE
[feat] 회원 정보 수정, 로그아웃, 회원탈퇴 기능 구현(#78)

### DIFF
--- a/backend/bookbook/src/main/java/com/bookbook/domain/user/controller/UserController.java
+++ b/backend/bookbook/src/main/java/com/bookbook/domain/user/controller/UserController.java
@@ -98,4 +98,22 @@ public class UserController {
         return ResponseEntity.ok(customOAuth2User != null);
     }
 
+
+    @DeleteMapping("/me") // 회원 탈퇴 엔드포인트
+    public ResponseEntity<String> deactivateUser(@AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+        if (customOAuth2User == null || customOAuth2User.getUserId() == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("로그인 정보가 유효하지 않습니다.");
+        }
+
+        try {
+            userService.deactivateUser(customOAuth2User.getUserId());
+            return ResponseEntity.ok("회원 탈퇴가 성공적으로 처리되었습니다.");
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(e.getMessage());
+        } catch (IllegalStateException e) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(e.getMessage()); // 409 Conflict
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("회원 탈퇴 처리 중 오류가 발생했습니다: " + e.getMessage());
+        }
+    }
 }

--- a/backend/bookbook/src/main/java/com/bookbook/domain/user/entity/User.java
+++ b/backend/bookbook/src/main/java/com/bookbook/domain/user/entity/User.java
@@ -118,4 +118,12 @@ public class User extends BaseEntity {
     public boolean isSuspended() {
         return userStatus == UserStatus.SUSPENDED;
     }
+
+    public void changeUsername(String username) {
+        this.username = username;
+    }
+
+    public void setEmail(String email) { // 이메일 변경 메서드 추가 (null 허용)
+        this.email = email;
+    }
 }

--- a/backend/bookbook/src/main/java/com/bookbook/domain/user/repository/UserRepository.java
+++ b/backend/bookbook/src/main/java/com/bookbook/domain/user/repository/UserRepository.java
@@ -16,6 +16,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
     List<User> findAllByUserStatusAndResumedAtBefore(UserStatus userStatus, LocalDateTime now);
 
     boolean existsByUsername(String username); // 사용자명 중복확인
-    boolean existsByEmail(String email); // 이메일 중복확인
     boolean existsByNickname(String nickname); // 닉네임 중복확인
 }

--- a/backend/bookbook/src/main/java/com/bookbook/global/security/securityConfig.java
+++ b/backend/bookbook/src/main/java/com/bookbook/global/security/securityConfig.java
@@ -40,6 +40,12 @@ public class securityConfig {
                         )
                         .successHandler(loginSuccessHandler) // OAuth2 로그인 성공 후 처리할 핸들러 지정
                 )
+                .logout(logout -> logout
+                        .logoutUrl("/api/v1/bookbook/users/logout") // 로그아웃을 처리할 URL
+                        .logoutSuccessUrl("http://localhost:3000/bookbook") // 로그아웃 성공 시 리다이렉트될 URL
+                        .invalidateHttpSession(true) // HTTP 세션 무효화
+                        .deleteCookies("JSESSIONID") // JSESSIONID 쿠키 삭제 (필요한 경우 다른 쿠키도 추가)
+                )
                 .headers(headers -> headers.frameOptions(frameOptions -> frameOptions.sameOrigin())); // H2 Console 사용을 위함
         return http.build();
     }


### PR DESCRIPTION
## 💡 변경 사항

// 예시

- [x] 회원 정보 수정 api 엔드포인트 지정 이전에 있던 메서드 재활용
- [x] 로그아웃 구현
- [x] 회원탈퇴 기능 구현

---

### ✅ 특이 사항
회원 정보 수정 기능은 이전에 회원 가입 기능이 소셜 로그인으로 받아온 정보를 수정하는 방식이라 이걸 재사용함

- 코드에서 특별히 설명해야 할 부분 (주석 등으로 드러나지 않는 부분)
- 코드 리뷰를 특별히 요청하고 싶은 부분

---

### 🔗 관련 이슈

closed #78 (#닫고싶은 이슈번호)
