### PR TITLE
fix 알림 페이지 로그인 기능 연동, 로그인 시 해당 회원 데이터 가져오기

### DIFF
--- a/backend/bookbook/src/main/java/com/bookbook/domain/notification/controller/NotificationController.java
+++ b/backend/bookbook/src/main/java/com/bookbook/domain/notification/controller/NotificationController.java
@@ -3,7 +3,9 @@ package com.bookbook.domain.notification.controller;
 import com.bookbook.domain.notification.dto.NotificationResponseDto;
 import com.bookbook.domain.notification.service.NotificationService;
 import com.bookbook.domain.user.entity.User;
+import com.bookbook.domain.user.service.UserService;
 import com.bookbook.global.rsdata.RsData;
+import com.bookbook.global.security.CustomOAuth2User;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,21 +22,30 @@ import java.util.List;
 public class NotificationController {
 
     private final NotificationService notificationService;
+    private final UserService userService;
 
     @Transactional(readOnly = true)
     @GetMapping
     @Operation(summary = "사용자 알림 조회", description = "현재 로그인한 사용자의 모든 알림을 최신순으로 조회합니다.")
     public RsData<List<NotificationResponseDto>> getNotifications(
-            @AuthenticationPrincipal User user
+            @AuthenticationPrincipal CustomOAuth2User customOAuth2User
     ) {
         // 로그인하지 않은 경우
-        if (user == null) {
+        if (customOAuth2User == null || customOAuth2User.getUserId() == null) {
             log.warn("인증되지 않은 사용자가 알림 조회를 시도했습니다.");
             return new RsData<>("401-1", "로그인 후 사용해주세요.", null);
         }
-        
-        log.debug("사용자 알림 조회 요청: {}", user.getUsername());
-        
+
+        log.debug("사용자 알림 조회 요청: 사용자 ID = {}, 사용자명 = {}",
+                customOAuth2User.getUserId(), customOAuth2User.getUsername());
+
+        // CustomOAuth2User에서 실제 User 엔티티를 조회
+        User user = userService.findById(customOAuth2User.getUserId());
+        if (user == null) {
+            log.error("사용자 ID {}에 해당하는 사용자를 찾을 수 없습니다.", customOAuth2User.getUserId());
+            return new RsData<>("404-1", "사용자 정보를 찾을 수 없습니다.", null);
+        }
+
         List<NotificationResponseDto> notifications = notificationService.getNotificationsByUser(user);
         return new RsData<>("200-1", "알림 목록을 조회했습니다.", notifications);
     }
@@ -43,12 +54,17 @@ public class NotificationController {
     @GetMapping("/unread-count")
     @Operation(summary = "읽지 않은 알림 개수", description = "현재 사용자의 읽지 않은 알림 개수를 조회합니다.")
     public RsData<Long> getUnreadCount(
-            @AuthenticationPrincipal User user
+            @AuthenticationPrincipal CustomOAuth2User customOAuth2User
     ) {
-        if (user == null) {
+        if (customOAuth2User == null || customOAuth2User.getUserId() == null) {
             return new RsData<>("401-1", "로그인 후 사용해주세요.", null);
         }
-        
+
+        User user = userService.findById(customOAuth2User.getUserId());
+        if (user == null) {
+            return new RsData<>("404-1", "사용자 정보를 찾을 수 없습니다.", null);
+        }
+
         long count = notificationService.getUnreadCount(user);
         return new RsData<>("200-1", "읽지 않은 알림 개수를 조회했습니다.", count);
     }
@@ -58,12 +74,17 @@ public class NotificationController {
     @Operation(summary = "알림 읽음 처리", description = "특정 알림을 읽음 상태로 변경합니다.")
     public RsData<Void> markAsRead(
             @PathVariable Long id,
-            @AuthenticationPrincipal User user
+            @AuthenticationPrincipal CustomOAuth2User customOAuth2User
     ) {
-        if (user == null) {
+        if (customOAuth2User == null || customOAuth2User.getUserId() == null) {
             return new RsData<>("401-1", "로그인 후 사용해주세요.", null);
         }
-        
+
+        User user = userService.findById(customOAuth2User.getUserId());
+        if (user == null) {
+            return new RsData<>("404-1", "사용자 정보를 찾을 수 없습니다.", null);
+        }
+
         try {
             notificationService.markAsRead(id, user);
             return RsData.of("200-1", "알림을 읽음 처리했습니다.");
@@ -77,12 +98,17 @@ public class NotificationController {
     @PatchMapping("/read-all")
     @Operation(summary = "모든 알림 읽음 처리", description = "사용자의 모든 알림을 읽음 상태로 변경합니다.")
     public RsData<Void> markAllAsRead(
-            @AuthenticationPrincipal User user
+            @AuthenticationPrincipal CustomOAuth2User customOAuth2User
     ) {
-        if (user == null) {
+        if (customOAuth2User == null || customOAuth2User.getUserId() == null) {
             return new RsData<>("401-1", "로그인 후 사용해주세요.", null);
         }
-        
+
+        User user = userService.findById(customOAuth2User.getUserId());
+        if (user == null) {
+            return new RsData<>("404-1", "사용자 정보를 찾을 수 없습니다.", null);
+        }
+
         notificationService.markAllAsRead(user);
         return RsData.of("200-1", "모든 알림을 읽음 처리했습니다.");
     }
@@ -92,12 +118,17 @@ public class NotificationController {
     @Operation(summary = "알림 삭제", description = "특정 알림을 삭제합니다.")
     public RsData<Void> deleteNotification(
             @PathVariable Long id,
-            @AuthenticationPrincipal User user
+            @AuthenticationPrincipal CustomOAuth2User customOAuth2User
     ) {
-        if (user == null) {
+        if (customOAuth2User == null || customOAuth2User.getUserId() == null) {
             return new RsData<>("401-1", "로그인 후 사용해주세요.", null);
         }
-        
+
+        User user = userService.findById(customOAuth2User.getUserId());
+        if (user == null) {
+            return new RsData<>("404-1", "사용자 정보를 찾을 수 없습니다.", null);
+        }
+
         try {
             notificationService.deleteNotification(id, user);
             return RsData.of("200-1", "알림을 삭제했습니다.");

--- a/backend/bookbook/src/main/java/com/bookbook/domain/user/service/UserService.java
+++ b/backend/bookbook/src/main/java/com/bookbook/domain/user/service/UserService.java
@@ -111,6 +111,10 @@ public class UserService {
         return userRepository.save(user);
     }
 
+    public User findById(Long id) {
+        return userRepository.findById(id).orElse(null);
+    }
+
     @Transactional
     public void deactivateUser(Long userId) {
         User user = userRepository.findById(userId)


### PR DESCRIPTION
## 💡 변경 사항

// 예시

- [x] 알림페이지 로그인시 사용자 관련 정보가져오기 구현
- [x] 로그인 안되어있으면 로그인해주세요 활성화 

---

### ✅ 특이 사항

- 예외로 보낼까하다가 이 부분이랑 service 단에서 처리하는 거랑 왜 service 단에서 추천했는지 찾아보았는데

--------------------------------
예외 흐름 최소화 → 코드 안정성 증가
예외는 진짜 비정상적 상황에서만 사용하는 것이 좋습니다.

사용자의 존재 여부는 일상적인 검사이기 때문에, 예외보다는 null 검사로 처리하는 것이 일반적이고 가독성도 좋습니다.

이런 응답을 받아서요. 아마 global 예외처리로 보내면 서비스의 책임이 적어지는거 같아 그런거 같습니다.
--------------------------------------------------------

---

### 🔗 관련 이슈

closed #1 (#닫고싶은 이슈번호)
