### PR TITLE
Feat/109 어드민 대시보드 게시글 목록 기능 추가 (수정)

### DIFF
--- a/backend/bookbook/src/main/java/com/bookbook/domain/user/controller/AdminController.java
+++ b/backend/bookbook/src/main/java/com/bookbook/domain/user/controller/AdminController.java
@@ -1,24 +1,28 @@
 package com.bookbook.domain.user.controller;
 
+import com.bookbook.domain.user.dto.ChangeRentStatusRequestDto;
+import com.bookbook.domain.rent.dto.RentResponseDto;
+import com.bookbook.domain.user.dto.RentSimpleResponseDto;
 import com.bookbook.domain.rent.service.RentService;
 import com.bookbook.domain.suspend.dto.request.UserSuspendRequestDto;
 import com.bookbook.domain.suspend.dto.response.UserResumeResponseDto;
 import com.bookbook.domain.suspend.dto.response.UserSuspendResponseDto;
 import com.bookbook.domain.suspend.entity.SuspendedUser;
 import com.bookbook.domain.suspend.service.SuspendedUserService;
+import com.bookbook.domain.user.dto.UserBaseDto;
+import com.bookbook.domain.user.dto.UserLoginRequestDto;
 import com.bookbook.domain.user.dto.response.PageResponse;
 import com.bookbook.domain.user.dto.response.UserDetailResponseDto;
 import com.bookbook.domain.user.dto.response.UserLoginResponseDto;
-import com.bookbook.domain.user.service.AdminService;
-import com.bookbook.domain.user.dto.UserBaseDto;
-import com.bookbook.domain.user.dto.UserLoginRequestDto;
 import com.bookbook.domain.user.entity.User;
+import com.bookbook.domain.user.service.AdminService;
 import com.bookbook.global.rsdata.RsData;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -32,71 +36,81 @@ public class AdminController {
     private final RentService rentService;
 
     @PostMapping("/login")
-    public RsData<UserLoginResponseDto> adminLogin(
+    public ResponseEntity<RsData<UserLoginResponseDto>> adminLogin(
             @Valid @RequestBody UserLoginRequestDto requestDto
     ) {
         User admin = adminService.login(requestDto);
         UserLoginResponseDto userLoginResponseDto = UserLoginResponseDto.from(admin);
 
-        return new RsData<>(
+        RsData<UserLoginResponseDto> body = new RsData<>(
                 "200-1",
                 "관리자 %s님이 로그인하였습니다.".formatted(admin.getUsername()),
                 userLoginResponseDto
         );
+
+        return ResponseEntity.status(body.getStatusCode()).body(body);
     }
 
     @DeleteMapping("/logout")
-    public RsData<Void> adminLogin() {
-        return new RsData<>(
-                "200-1",
+    public ResponseEntity<RsData<Void>> adminLogout() {
+        RsData<Void> rsData = new RsData<>(
+                "204-1",
                 "로그아웃을 정상적으로 완료했습니다.",
                 null
         );
+
+        return ResponseEntity.status(rsData.getStatusCode()).body(rsData);
     }
 
-    @PutMapping("/users/suspend")
-    public RsData<UserSuspendResponseDto> suspendUser(
+    @PatchMapping("/users/suspend")
+    public ResponseEntity<RsData<UserSuspendResponseDto>> suspendUser(
             @RequestBody UserSuspendRequestDto requestDto
     ) {
         SuspendedUser suspendedUser = suspendedUserService.addUserAsSuspended(requestDto);
         UserSuspendResponseDto userSuspendResponseDto = UserSuspendResponseDto.from(suspendedUser);
 
-        return new RsData<>(
+        RsData<UserSuspendResponseDto> rsData = new RsData<>(
                 "201-1",
                 "%s님을 정지하였습니다",
                 userSuspendResponseDto
         );
+
+        return ResponseEntity.status(rsData.getStatusCode()).body(rsData);
     }
 
     @GetMapping("/users/{userId}")
-    public RsData<UserDetailResponseDto> getUserDetail(
+    public ResponseEntity<RsData<UserDetailResponseDto>> getUserDetail(
             @PathVariable Long userId
     ) {
         UserDetailResponseDto specificUserInfo = adminService.getSpecificUserInfo(userId);
 
-        return new RsData<>(
+        RsData<UserDetailResponseDto> rsData = new RsData<>(
                 "200-1",
                 "%d 유저의 정보를 찾았습니다.".formatted(specificUserInfo.baseResponseDto().id()),
                 specificUserInfo
         );
+
+        return ResponseEntity.status(rsData.getStatusCode()).body(rsData);
     }
 
-    @PutMapping("/users/{userId}/resume")
-    public RsData<UserResumeResponseDto> resumeUser(
+    @PatchMapping("/users/{userId}/resume")
+    public ResponseEntity<RsData<UserResumeResponseDto>> resumeUser(
             @PathVariable Long userId
     ) {
         User user = suspendedUserService.resumeUser(userId);
         UserResumeResponseDto responseDto = UserResumeResponseDto.from(user);
 
-        return new RsData<>(
+        RsData<UserResumeResponseDto> rsData = new RsData<>(
                 "200-1",
                 "%d번 유저의 정지가 해제되었습니다.".formatted(user.getId()),
                 responseDto
         );
+
+        return  ResponseEntity.status(rsData.getStatusCode()).body(rsData);
     }
 
     @GetMapping("/users")
-    public RsData<PageResponse<UserBaseDto>> getFilteredUsers(
+    public ResponseEntity<RsData<PageResponse<UserBaseDto>>> getFilteredUsers(
             @RequestParam(defaultValue = "1") Integer page,
             @RequestParam(defaultValue = "10") Integer size,
             @RequestParam(required = false) List<String> status,
@@ -107,15 +121,17 @@ public class AdminController {
         Page<UserBaseDto> userPage = adminService.getFilteredUsers(pageable, status, userId);
         PageResponse<UserBaseDto> response = PageResponse.from(userPage, page, size);
 
-        return new RsData<>(
+        RsData<PageResponse<UserBaseDto>> rsData = new RsData<>(
                 "200-1",
                 "해당 조건에 맞는 %d명의 유저를 찾았습니다.".formatted(userPage.getTotalElements()),
                 response
         );
+
+        return ResponseEntity.status(rsData.getStatusCode()).body(rsData);
     }
 
     @GetMapping("/users/suspend")
-    public RsData<PageResponse<UserSuspendResponseDto>> getAllSuspendedHistory(
+    public ResponseEntity<RsData<PageResponse<UserSuspendResponseDto>>> getAllSuspendedHistory(
             @RequestParam(defaultValue = "1") Integer page,
             @RequestParam(defaultValue = "10") Integer size
     ) {
@@ -124,24 +140,47 @@ public class AdminController {
         Page<UserSuspendResponseDto> historyPage = suspendedUserService.getSuspendedHistoryPage(pageable);
         PageResponse<UserSuspendResponseDto> response = PageResponse.from(historyPage, page, size);
 
-        return new RsData<>(
+        RsData<PageResponse<UserSuspendResponseDto>> rsData = new RsData<>(
                 "200-1",
                 "%d개의 정지 이력을 발견했습니다".formatted(historyPage.getTotalElements()),
                 response
         );
+
+        return  ResponseEntity.status(rsData.getStatusCode()).body(rsData);
     }
 
-//    @GetMapping("/posts")
-//    public RsData<List<RentSimpleResponseDto>> getPosts() {
-//        List<RentSimpleResponseDto> allRents = rentService.getAllRents();
-//
-//        return new RsData<>(
-//                "200-1",
-//                "%d개의 글을 발견했습니다.".formatted(allRents.size()),
-//                allRents
-//        );
-//    }
+    @GetMapping("/posts")
+    public ResponseEntity<RsData<PageResponse<RentSimpleResponseDto>>> getPosts(
+            @RequestParam(defaultValue = "1") Integer page,
+            @RequestParam(defaultValue = "10") Integer size,
+            @RequestParam(required = false) List<String> status,
+            @RequestParam(required = false) String nickname
+    ) {
+        Pageable pageable = PageRequest.of(page - 1, size);
 
-//    @GetMapping("/reports")
-//    public
+        Page<RentSimpleResponseDto> rentHistoryPage = rentService.getRentsPage(pageable, status, nickname);
+        PageResponse<RentSimpleResponseDto> response = PageResponse.from(rentHistoryPage, page, size);
+
+        RsData<PageResponse<RentSimpleResponseDto>> rsData = new RsData<>(
+                "200-1",
+                "%d개의 글을 발견했습니다.".formatted(rentHistoryPage.getTotalElements()),
+                response
+        );
+
+        return ResponseEntity.status(rsData.getStatusCode()).body(rsData);
+    }
+
+    @PatchMapping("/rent/{id}") // /rent/{id} 경로로 patch 요청을 처리
+    public RsData<RentResponseDto> changeRentStatus(
+            @PathVariable int id,
+            @RequestBody ChangeRentStatusRequestDto status
+    ){ // 경로 변수로 전달된 id를 사용
+        RentResponseDto rentResponseDto = rentService.modifyRentPageStatus(id, status);
+
+        return new RsData<>(
+                "200-1",
+                "%d 번 글 삭제 완료",
+                rentResponseDto
+        );
+    }
 }

--- a/backend/bookbook/src/main/java/com/bookbook/domain/user/controller/AdminController.java
+++ b/backend/bookbook/src/main/java/com/bookbook/domain/user/controller/AdminController.java
@@ -1,8 +1,5 @@
 package com.bookbook.domain.user.controller;
 
-import com.bookbook.domain.user.dto.ChangeRentStatusRequestDto;
-import com.bookbook.domain.rent.dto.RentResponseDto;
-import com.bookbook.domain.user.dto.RentSimpleResponseDto;
 import com.bookbook.domain.rent.service.RentService;
 import com.bookbook.domain.suspend.dto.request.UserSuspendRequestDto;
 import com.bookbook.domain.suspend.dto.response.UserResumeResponseDto;
@@ -149,6 +146,7 @@ public class AdminController {
         return  ResponseEntity.status(rsData.getStatusCode()).body(rsData);
     }
 
+    /*
     @GetMapping("/posts")
     public ResponseEntity<RsData<PageResponse<RentSimpleResponseDto>>> getPosts(
             @RequestParam(defaultValue = "1") Integer page,
@@ -183,4 +181,5 @@ public class AdminController {
                 rentResponseDto
         );
     }
+     */
 }

--- a/backend/bookbook/src/main/java/com/bookbook/domain/user/dto/ChangeRentStatusRequestDto.java
+++ b/backend/bookbook/src/main/java/com/bookbook/domain/user/dto/ChangeRentStatusRequestDto.java
@@ -1,0 +1,8 @@
+package com.bookbook.domain.user.dto;
+
+import lombok.NonNull;
+
+public record ChangeRentStatusRequestDto(
+        @NonNull String status
+) {
+}

--- a/backend/bookbook/src/main/java/com/bookbook/domain/user/dto/RentSimpleResponseDto.java
+++ b/backend/bookbook/src/main/java/com/bookbook/domain/user/dto/RentSimpleResponseDto.java
@@ -1,0 +1,34 @@
+package com.bookbook.domain.user.dto;
+
+import com.bookbook.domain.rent.entity.Rent;
+import lombok.Builder;
+import lombok.NonNull;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record RentSimpleResponseDto(
+        @NonNull Integer id,
+        @NonNull Long lenderUserId,
+        @NonNull String status,
+        @NonNull String bookCondition,
+        @NonNull String bookTitle,
+        @NonNull String author,
+        @NonNull String publisher,
+        @NonNull LocalDateTime createdDate,
+        @NonNull LocalDateTime modifiedDate
+){
+    public static RentSimpleResponseDto from(Rent rent) {
+        return RentSimpleResponseDto.builder()
+                .id(rent.getId())
+                .lenderUserId(rent.getLenderUserId())
+                .status(rent.getRentStatus())
+                .bookCondition(rent.getBookCondition())
+                .bookTitle(rent.getBookTitle())
+                .author(rent.getAuthor())
+                .publisher(rent.getPublisher())
+                .createdDate(rent.getCreatedDate())
+                .modifiedDate(rent.getModifiedDate())
+                .build();
+    }
+}

--- a/backend/bookbook/src/main/java/com/bookbook/domain/user/dto/UserBaseDto.java
+++ b/backend/bookbook/src/main/java/com/bookbook/domain/user/dto/UserBaseDto.java
@@ -11,8 +11,9 @@ import java.time.LocalDateTime;
 @Builder
 public record UserBaseDto(
         @NonNull Long id,
-        @NonNull String username,
-        @NonNull String nickname,
+        String username,
+        String nickname,
+        String email,
         @NonNull Float rating,
         @NonNull LocalDateTime createdAt,
         @NonNull LocalDateTime updatedAt,
@@ -25,6 +26,7 @@ public record UserBaseDto(
                 .id(user.getId())
                 .username(user.getUsername())
                 .nickname(user.getNickname())
+                .email(user.getEmail())
                 .rating(user.getRating())
                 .createdAt(user.getCreateAt())
                 .updatedAt(user.getUpdateAt())

--- a/backend/bookbook/src/main/java/com/bookbook/domain/user/service/AdminService.java
+++ b/backend/bookbook/src/main/java/com/bookbook/domain/user/service/AdminService.java
@@ -1,10 +1,12 @@
 package com.bookbook.domain.user.service;
 
-import com.bookbook.domain.user.dto.response.UserDetailResponseDto;
 import com.bookbook.domain.user.dto.UserBaseDto;
 import com.bookbook.domain.user.dto.UserLoginRequestDto;
+import com.bookbook.domain.user.dto.response.UserDetailResponseDto;
 import com.bookbook.domain.user.entity.User;
+import com.bookbook.domain.user.enums.Role;
 import com.bookbook.domain.user.repository.UserRepository;
+import com.bookbook.global.exception.ServiceException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -27,6 +29,10 @@ public class AdminService {
                 .orElseThrow(() -> new RuntimeException("존재하지 않는 계정입니다"));
 
         checkPassword(user, reqBody.getPassword());
+
+        if (user.getRole() != Role.ADMIN) {
+            throw new ServiceException("401-1", "허가되지 않은 접근입니다.");
+        }
 
         return user;
     }

--- a/frontend/src/app/admin/dashboard/_components/adminProfile.tsx
+++ b/frontend/src/app/admin/dashboard/_components/adminProfile.tsx
@@ -8,7 +8,7 @@ interface AdminProfileProps {
   admin: UserLoginResponseDto;
   onLogout: () => void;
 }
-  
+
 // 관리자 프로필 영역 컴포넌트
 export function AdminProfile(props: AdminProfileProps) {
   const { admin, onLogout } = props;
@@ -19,9 +19,9 @@ export function AdminProfile(props: AdminProfileProps) {
     setShowDropdown(false);
     onLogout();
     setShowConfirmModal(false);
-  }
+  };
 
-  const avatar = admin?.avatar ? admin.avatar : "";
+  const avatar = "";
   const username = admin?.username ? admin.username : "";
   const nickname = admin?.nickname ? admin.nickname : "";
   const role = admin?.role ? admin.role : "";
@@ -82,10 +82,10 @@ export function AdminProfile(props: AdminProfileProps) {
         </div>
       </div>
       {showConfirmModal && (
-          <ConfirmModal
-            message="로그아웃이 완료되었습니다"
-            onConfirm={handleLogout}
-          />
+        <ConfirmModal
+          message="로그아웃이 완료되었습니다"
+          onConfirm={handleLogout}
+        />
       )}
     </>
   );

--- a/frontend/src/app/admin/dashboard/_components/common/Table.tsx
+++ b/frontend/src/app/admin/dashboard/_components/common/Table.tsx
@@ -41,10 +41,11 @@ export function DataTable<T extends { id: string | number }>(
 
   const PER_PAGE = 10;
   const currentPage = data?.pageInfo?.currentPage || 1;
-  const pagedData = data ? data.data : [];
+  const pagedData = data?.data || [];
+  const maxPage = data?.pageInfo?.totalPages || 0;
 
   const getDataFromButton = (newPage: number) => {
-    if (!currentItem || !currentItem.apiPath || currentItem.apiPath.trim().length === 0) {
+    if (!currentItem || !currentItem.apiPath || !currentItem.apiPath.trim()) {
       return;
     }
 
@@ -77,7 +78,7 @@ export function DataTable<T extends { id: string | number }>(
             </tr>
           </thead>
           <tbody className="bg-white divide-y divide-gray-200">
-            {pagedData.length > 0 ? (
+            {pagedData?.length > 0 ? (
               pagedData.map((item) => (
                 <tr key={item.id} className="hover:bg-gray-50 transition-colors">
                   {columns.map((col) => (
@@ -90,7 +91,7 @@ export function DataTable<T extends { id: string | number }>(
               ))
               ) : (
                 <tr>
-                  <td colSpan={columns.length} className="px-6 py-12 text-center text-sm text-gray-500">
+                  <td colSpan={columns?.length} className="px-6 py-12 text-center text-sm text-gray-500">
                     데이터가 없습니다.
                   </td>
                 </tr>
@@ -98,7 +99,7 @@ export function DataTable<T extends { id: string | number }>(
           </tbody>
         </table>
       </div>
-      {data.pageInfo.totalPages > 0 && (
+      {maxPage > 0 && (
         <
           PageButtonContainer
             page={currentPage}

--- a/frontend/src/app/admin/dashboard/_components/common/Table.tsx
+++ b/frontend/src/app/admin/dashboard/_components/common/Table.tsx
@@ -72,7 +72,7 @@ export function DataTable<T extends { id: string | number }>(
                   scope="col"
                   className="px-6 py-3 text-left text-xs font-bold text-gray-600 uppercase tracking-wider"
                 >
-                  {col.label}
+                  {col.label?.length > 0 ? col.label : "정보 없음"}
                 </th>
               ))}
             </tr>

--- a/frontend/src/app/admin/dashboard/_components/mainContent/listComponentContainer.tsx
+++ b/frontend/src/app/admin/dashboard/_components/mainContent/listComponentContainer.tsx
@@ -73,7 +73,6 @@ export function ListComponentContainer() {
         );
     }
 
-
     return (
         <ContentComponent
             data={data}

--- a/frontend/src/app/admin/dashboard/_components/mainContent/suspendedUserListComponent.tsx
+++ b/frontend/src/app/admin/dashboard/_components/mainContent/suspendedUserListComponent.tsx
@@ -11,7 +11,6 @@ export function SuspendedUserListComponent({ data }: ContentComponentProps) {
     { key: "id", label: "No" },
     { key: "userId", label: "아이디" },
     { key: "name", label: "이름" },
-    { key: "email", label: "이메일" },
     {
       key: "suspendedAt",
       label: "정지일",

--- a/frontend/src/app/admin/dashboard/_components/mainContent/userListComponent.tsx
+++ b/frontend/src/app/admin/dashboard/_components/mainContent/userListComponent.tsx
@@ -7,8 +7,8 @@ import { formatDate } from "../common/dateFormatter";
 import UserDetailModal from "../user/manage/userDetailModal";
 import { ContentComponentProps } from "./baseContentComponentProps";
 import { UserFilterContainer, FilterState } from "../user/filter";
-import { PageResponse } from "../../_types/page";
-import {useDashBoardContext} from "@/app/admin/dashboard/_hooks/useDashboard";
+import { useDashBoardContext } from "@/app/admin/dashboard/_hooks/useDashboard";
+import apiClient from "@/app/bookbook/user/utils/apiClient";
 
 interface ManagementButtonProps {
   user: UserBaseResponseDto;
@@ -75,21 +75,9 @@ export function UserListComponent({
   const handleManageClick = async (user: UserBaseResponseDto) => {
     console.log(`관리 버튼 클릭: 멤버 ID - ${user.id}, 닉네임 - ${user.nickname}`);
 
-    fetch(`http://localhost:8080/api/v1/admin/users/${user.id}`, {
+    apiClient(`/api/v1/admin/users/${user.id}`, {
       method: "GET",
-      headers: {
-        "Content-Type": "application/json; charset=utf-8",
-      },
-      credentials: "include",
     })
-      .then((response) => {
-        if (!response.ok) {
-          setSelectedUser(null as unknown as UserDetailResponseDto);
-          return;
-        }
-
-        return response.json();
-      })
       .then((data) => {
         console.log(data);
         setSelectedUser(data.data as UserDetailResponseDto);
@@ -165,7 +153,7 @@ export function UserListComponent({
   }
 
   const doSearch = () => {
-    if (!currentItem || !currentItem.apiPath || currentItem.apiPath.trim().length === 0) {
+    if (!currentItem || !currentItem?.apiPath || !currentItem.apiPath.trim()) {
       return;
     }
 
@@ -221,7 +209,7 @@ export function UserListComponent({
         {/* 헤더 */}
         <div className="flex items-center justify-between">
           <h3 className="text-lg font-semibold text-gray-900">
-            전체 멤버 목록
+            멤버 목록
           </h3>
             <div className="text-sm text-gray-500">
               {data.data.length > 0 ? `총 ${data.data.length}명 검색 완료` : "검색 결과 없음"}

--- a/frontend/src/app/admin/dashboard/_components/mainContent/userListComponent.tsx
+++ b/frontend/src/app/admin/dashboard/_components/mainContent/userListComponent.tsx
@@ -166,6 +166,7 @@ export function UserListComponent({
     { key: "id", label: "No" },
     { key: "username", label: "유저명" },
     { key: "nickname", label: "닉네임" },
+    { key: "email", label: "이메일" },
     {
       key: "createdAt",
       label: "가입일",

--- a/frontend/src/app/admin/dashboard/_components/mainContent/userRentPostComponent.tsx
+++ b/frontend/src/app/admin/dashboard/_components/mainContent/userRentPostComponent.tsx
@@ -1,104 +1,255 @@
 'use client';
 
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { DataTable, ColumnDefinition } from "../common/Table";
-import { RentPost } from "../../_types/rentPost";
+import {getRentStatus, RentPostDetailResponseDto, RentPostSimpleResponseDto, rentStatus} from "../../_types/rentPost";
 import { ContentComponentProps } from "./baseContentComponentProps";
-
-// --- Mock Data ---
-const mockRentPosts: RentPost[] = [
-    {
-        id: 1,
-        lenderId: 1,
-        name: "매니저",
-        title: "이 책 재밌읍니다",
-        author: "작자미상",
-        publisher: "나",
-        rentStatus: "대기중",
-        createdDate: "25-05-06",
-        modifiedDate: "25-05-06",
-    },
-    {
-        id: 2,
-        lenderId: 2,
-        name: "매니저2",
-        title: "이 책 재밌읍니다2",
-        author: "작자미상",
-        publisher: "너",
-        rentStatus: "대출중",
-        createdDate: "25-05-06",
-        modifiedDate: "25-05-06",
-    },
-    {
-        id: 3,
-        lenderId: 3,
-        name: "매니저3",
-        title: "이 책 재밌읍니다3",
-        author: "작자미상",
-        publisher: "우리",
-        rentStatus: "중단",
-        createdDate: "25-05-06",
-        modifiedDate: "25-05-06",
-    }
-];
+import { FilterState, PostFilterContainer } from "@/app/admin/dashboard/_components/post/filter";
+import { useDashBoardContext } from "@/app/admin/dashboard/_hooks/useDashboard";
+import Link from "next/link";
+import apiClient from "@/app/bookbook/user/utils/apiClient";
+import {formatDate} from "@/app/admin/dashboard/_components/common/dateFormatter";
+import PostDetailWithUserModal from "../post/manage/postDetailWithUserModal";
 
 interface ManagementButtonProps {
-    rentPost: RentPost;
-    onClick: (id: number) => void;
+    rentPost: RentPostSimpleResponseDto;
+    onClick: (post: RentPostSimpleResponseDto) => void;
 }
 
 function ManagementButton({ rentPost, onClick }: ManagementButtonProps) {
     return (
         <button
-            onClick={() => onClick(rentPost.id)}
+            onClick={() => onClick(rentPost)}
             className="px-3 py-1.5 text-xs font-medium text-gray-700 bg-white border border-gray-300 rounded-md shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-slate-500 transition-colors"
         >
-            클릭
+            관리
         </button>
     );
 }
 
-export function UserRentPostComponent({ data }: ContentComponentProps) {
-    const handleManageClick = (postId: number) => {
-        console.log(`관리 버튼 클릭: 글 ID - ${postId}`);
-        // TODO: 작성된 글로 이동
+export function UserRentPostComponent({ data, onRefresh }: ContentComponentProps) {
+    // data가 없거나 잘못된 형태일 때 기본값 설정
+    const [selectedRentPost, setSelectedRentPost] = useState<RentPostDetailResponseDto>(
+        null as unknown as RentPostDetailResponseDto
+    );
+    const [selectedRentPostId, setSelectedRentPostId] = useState(0);
+    const [isModalOpen, setIsModalOpen] = useState(false);
+    const { currentItem, fetchData } = useDashBoardContext();
+
+    const getInitialFilters = (): FilterState => {
+        try {
+            const saved = sessionStorage.getItem('admin-post-list-filters');
+            if (saved) {
+                const parsed = JSON.parse(saved);
+                return {
+                    statuses: new Set(parsed.statuses || ["AVAILABLE", "LOANED", "FINISHED"]),
+                    searchTerm: parsed.searchTerm || "",
+                };
+            }
+        } catch (error) {
+            console.warn('필터 상태 복원 실패:', error);
+        }
+
+        return {
+            statuses: new Set(["AVAILABLE", "LOANED", "FINISHED"]),
+            searchTerm: "",
+        };
     };
 
-    const [suspendedMembers, setsuspendedMembers] = useState<RentPost[]>([]);
+    const [filters, setFilters] = useState<FilterState>(getInitialFilters);
+
+    const saveFilters = useCallback(() => {
+        try {
+            const toSave = {
+                statuses: Array.from(filters.statuses),
+                searchTerm: filters.searchTerm,
+            };
+            sessionStorage.setItem('admin-post-list-filters', JSON.stringify(toSave));
+        } catch (error) {
+            console.warn('필터 상태 저장 실패:', error);
+        }
+    }, [filters]);
+
+    const handleManageClick = async (post : RentPostSimpleResponseDto) => {
+        console.log(`관리 버튼 클릭: 멤버 ID - ${post.id}`);
+
+        apiClient(`/bookbook/rent/${post.id}`, {
+            method: "GET",
+        }).then((data) => {
+            console.log(data.data);
+            setSelectedRentPost(data.data as RentPostDetailResponseDto);
+            setSelectedRentPostId(post.id);
+        });
+
+        setIsModalOpen(true);
+    };
+
+    const handleModalClose = () => {
+        setIsModalOpen(false);
+        setSelectedRentPost(null as unknown as RentPostDetailResponseDto);
+    };
 
     useEffect(() => {
-        if (data) {
-            // setSuspendedMembers(responseData);
-        }
-        // 테스트 목적으로 추가했습니다
-        setsuspendedMembers(mockRentPosts);
-    }, [data]);
+        saveFilters();
+    }, [saveFilters]);
 
-    const columns: ColumnDefinition<RentPost>[] = [
+    const handleStatusToggle = (status: rentStatus) => {
+        const newStatuses = new Set(filters.statuses);
+        if (newStatuses.has(status)) {
+            newStatuses.delete(status);
+        } else {
+            newStatuses.add(status);
+        }
+
+        if (newStatuses.size === 0) {
+            setFilters((prev) => ({ ...prev, statuses: new Set(["AVAILABLE", "LOANED", "FINISHED"])}));
+        } else {
+            setFilters((prev) => ({ ...prev, statuses: newStatuses }));
+        }
+    };
+
+    const handleSelectAll = () => {
+        const allStatuses: rentStatus[] = ["AVAILABLE", "LOANED", "FINISHED"];
+        const isAllSelected = allStatuses.every((status) =>
+            filters.statuses.has(status)
+        );
+
+        if (isAllSelected) {
+            setFilters((prev) => ({ ...prev, statuses: new Set() }));
+        } else {
+            setFilters((prev) => ({ ...prev, statuses: new Set(allStatuses) }));
+        }
+    };
+
+    const handleSearchChange = (value: string) => {
+        setFilters((prev) => ({ ...prev, searchTerm: value }));
+    };
+
+    const resetFilters = () => {
+        const resetState: FilterState = {
+            statuses: new Set(["AVAILABLE", "LOANED", "FINISHED"]),
+            searchTerm: "",
+        };
+        setFilters(resetState);
+    };
+
+    const searchFromFilter = () => {
+        const params = new URLSearchParams();
+
+        filters.statuses.forEach(status => params.append("status", status));
+
+        if (filters.searchTerm) {
+            const nickname = filters.searchTerm.trim();
+            params.append("nickname", `${nickname}`);
+        }
+
+        return params
+    }
+
+    const doSearch = () => {
+        if (!currentItem || !currentItem.apiPath || currentItem.apiPath.trim().length === 0) {
+            return;
+        }
+
+        const params = searchFromFilter();
+        const requestPath = `${currentItem.apiPath}?${params.toString()}`;
+        fetchData(requestPath);
+    }
+
+    const columns: ColumnDefinition<RentPostSimpleResponseDto>[] = [
         { key: "id", label: "No" },
-        { key: "lenderId", label: "대여자 ID" },
-        { key: "name", label: "이름" },
-        { key: "title", label: "도서명" },
+        { key: "lenderUserId", label: "대여자 ID" },
+        {
+            key: "status",
+            label: "대여 상태",
+            render: post => (
+                <>{getRentStatus(post.status)}</>
+            )
+        },
+        { key: "bookCondition", label: "도서 상태" },
+        {
+            key: "bookTitle",
+            label: "도서명",
+            render: (post =>
+                <>
+                    {post.bookTitle?.length >= 15
+                        ? post.bookTitle.slice(0, 15) + "..."
+                        : post.bookTitle}
+                </>
+            )
+        },
         { key: "author", label: "작가" },
-        { key: "publisher", label: "출판사" },
-        { key: "rentStatus", label: "대여 상태" },
-        { key: "createdDate", label: "작성일"},
-        { key: "modifiedDate", label: "수정일"},
+        {
+            key: "createdDate",
+            label: "작성일",
+            render: (post) => <span>{formatDate(post.createdDate)}</span>
+        },
+        {
+            key: "modifiedDate",
+            label: "수정일",
+            render: (post) => <span>{formatDate(post.modifiedDate)}</span>,
+        },
         {
             key: "actions",
-            label: "링크",
+            label: "포스트",
+            render: (rentPost) => (
+                <Link href={`/bookbook/rent/${rentPost.id}`} target="_blank">
+                    <button className="px-3 py-1.5 text-xs font-medium text-gray-700 bg-white border border-gray-300 rounded-md shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-slate-500 transition-colors">
+                        이동
+                    </button>
+                </Link>
+            ),
+        },
+        {
+            key: "management",
+            label: "관리",
             render: (rentPost) => (
                 <ManagementButton rentPost={rentPost} onClick={handleManageClick} />
             ),
-        },
+        }
     ];
 
     return (
-        <>
-            <h3 className="text-lg font-semibold text-gray-900 mb-4">
-                글 작성 목록
-            </h3>
-            <DataTable columns={columns} data={data} />
-        </>
+        <div className="space-y-4">
+            {/* 헤더 */}
+            <div className="flex items-center justify-between">
+                <h3 className="text-lg font-semibold text-gray-900">
+                    멤버 목록
+                </h3>
+                <div className="text-sm text-gray-500">
+                    {(data?.data?.length ?? 0) > 0 ? `총 ${data.data.length}건 검색 완료` : "검색 결과 없음"}
+                </div>
+            </div>
+
+                {/* 필터 및 검색 영역 */}
+            <PostFilterContainer
+                filters={filters}
+                onStatusToggle={handleStatusToggle}
+                onSelectAll={handleSelectAll}
+                onSearchTermChange={handleSearchChange}
+                onReset={resetFilters}
+                onSearch={doSearch}
+            />
+
+                {/* 테이블 */}
+            <div className="bg-white rounded-lg border border-gray-200">
+                <DataTable
+                    columns={columns}
+                    data={data}
+                    pageFactory={searchFromFilter}
+                />
+            </div>
+
+            {/* 멤버 상세 정보 모달 */}
+            {selectedRentPost && (
+                <PostDetailWithUserModal
+                    id={selectedRentPostId}
+                    post={selectedRentPost}
+                    isOpen={isModalOpen}
+                    onClose={handleModalClose}
+                    onRefresh={onRefresh} // 새로고침 함수 전달
+                />
+            )}
+        </div>
     );
 }

--- a/frontend/src/app/admin/dashboard/_components/mainContent/userRentPostComponent.tsx
+++ b/frontend/src/app/admin/dashboard/_components/mainContent/userRentPostComponent.tsx
@@ -214,7 +214,7 @@ export function UserRentPostComponent({ data, onRefresh }: ContentComponentProps
             {/* 헤더 */}
             <div className="flex items-center justify-between">
                 <h3 className="text-lg font-semibold text-gray-900">
-                    멤버 목록
+                    대여 글 목록
                 </h3>
                 <div className="text-sm text-gray-500">
                     {(data?.data?.length ?? 0) > 0 ? `총 ${data.data.length}건 검색 완료` : "검색 결과 없음"}

--- a/frontend/src/app/admin/dashboard/_components/post/filter/index.ts
+++ b/frontend/src/app/admin/dashboard/_components/post/filter/index.ts
@@ -1,0 +1,3 @@
+export { PostStatusFilter } from './postStatusFilter';
+export { PostSearchBox } from './postSearchBox';
+export { PostFilterContainer, type FilterState } from './postFilterContainer';

--- a/frontend/src/app/admin/dashboard/_components/post/filter/postFilterContainer.tsx
+++ b/frontend/src/app/admin/dashboard/_components/post/filter/postFilterContainer.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import React from "react";
+import { PostStatusFilter } from "./postStatusFilter";
+import { PostSearchBox } from "./postSearchBox";
+import {rentStatus} from "@/app/admin/dashboard/_types/rentPost";
+
+interface FilterState {
+  statuses: Set<rentStatus>;
+  searchTerm: string;
+}
+
+interface UserFilterContainerProps {
+  filters: FilterState;
+  onStatusToggle: (status: rentStatus) => void;
+  onSelectAll: () => void;
+  onSearchTermChange: (value: string) => void;
+  onReset: () => void;
+  onSearch: () => void;
+}
+
+export function PostFilterContainer({
+  filters,
+  onStatusToggle,
+  onSelectAll,
+  onSearchTermChange,
+  onReset,
+  onSearch,
+}: UserFilterContainerProps) {
+  return (
+    <div className="bg-white border border-gray-200 rounded-lg p-4 space-y-4">
+      {/* 상태 필터 */}
+      <PostStatusFilter
+        selectedStatuses={filters.statuses}
+        onStatusToggle={onStatusToggle}
+        onSelectAll={onSelectAll}
+      />
+
+      {/* 검색 */}
+      <PostSearchBox
+        searchTerm={filters.searchTerm}
+        onSearchTermChange={onSearchTermChange}
+        onReset={onReset}
+        onSearch={onSearch}
+      />
+    </div>
+  );
+}
+
+export type { FilterState };

--- a/frontend/src/app/admin/dashboard/_components/post/filter/postSearchBox.tsx
+++ b/frontend/src/app/admin/dashboard/_components/post/filter/postSearchBox.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import React from "react";
+
+interface PostSearchBoxProps {
+  searchTerm: string;
+  onSearchTermChange: (value: string) => void;
+  onReset: () => void;
+  onSearch?: () => void;
+}
+
+export function PostSearchBox({
+  searchTerm,
+  onSearchTermChange,
+  onReset,
+  onSearch,
+}: PostSearchBoxProps) {
+  return (
+    <div>
+      <label className="block text-sm font-medium text-gray-700 mb-2">
+        검색
+      </label>
+      <div className="flex gap-2">
+        <input
+          type="text"
+          value={searchTerm}
+          onChange={(e) => onSearchTermChange(e.target.value)}
+          placeholder="유저명으로도 검색..."
+          className="flex-1 block px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 text-sm"
+        />
+
+        <button
+          onClick={onReset}
+          className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+        >
+          초기화
+        </button>
+
+        <button
+          onClick={onSearch}
+          className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+        >
+          검색
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/admin/dashboard/_components/post/filter/postStatusFilter.tsx
+++ b/frontend/src/app/admin/dashboard/_components/post/filter/postStatusFilter.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import React from "react";
+import {getRentStatus, rentStatus} from "@/app/admin/dashboard/_types/rentPost";
+
+interface PostStatusFilterProps {
+  selectedStatuses: Set<rentStatus>;
+  onStatusToggle: (status: rentStatus) => void;
+  onSelectAll: () => void;
+}
+
+interface PostStatusFilterState {
+  checked: boolean;
+  onChange: () => void;
+  value: string;
+  fontStyle: string
+}
+
+function PostStatusFilterItem({ checked, onChange, fontStyle, value} : PostStatusFilterState) {
+  return (
+      <label className="flex items-center">
+        <input
+            type="checkbox"
+            checked={checked}
+            onChange={onChange}
+            className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
+        />
+        <span className={fontStyle}>{value}</span>
+      </label>
+  )
+}
+
+export function PostStatusFilter({
+  selectedStatuses,
+  onStatusToggle,
+  onSelectAll,
+}: PostStatusFilterProps) {
+  const allStatuses: rentStatus[] = ["AVAILABLE", "LOANED", "FINISHED"];
+
+  const isAllSelected = allStatuses.every((status) =>
+    selectedStatuses.has(status)
+  );
+
+  return (
+    <div>
+      <label className="block text-sm font-medium text-gray-700 mb-2">
+        회원 상태
+      </label>
+      <div className="flex flex-wrap gap-3">
+        <PostStatusFilterItem
+          checked={isAllSelected}
+          onChange={onSelectAll}
+          fontStyle="ml-2 text-sm text-gray-700 font-medium"
+          value="전체"
+        />
+
+        <PostStatusFilterItem
+            checked={selectedStatuses.has("AVAILABLE")}
+            onChange={() => onStatusToggle("AVAILABLE")}
+            fontStyle="ml-2 text-sm text-green-700"
+            value={getRentStatus("AVAILABLE")}
+        />
+
+        <PostStatusFilterItem
+            checked={selectedStatuses.has("LOANED")}
+            onChange={() => onStatusToggle("LOANED")}
+            fontStyle="ml-2 text-sm text-red-700"
+            value={getRentStatus("LOANED")}
+        />
+
+        <PostStatusFilterItem
+            checked={selectedStatuses.has("FINISHED")}
+            onChange={() => onStatusToggle("FINISHED")}
+            fontStyle="ml-2 text-sm text-gray-700"
+            value={getRentStatus("FINISHED")}
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/admin/dashboard/_components/post/manage/postBasicInfo.tsx
+++ b/frontend/src/app/admin/dashboard/_components/post/manage/postBasicInfo.tsx
@@ -1,0 +1,56 @@
+import { RentPostDetailResponseDto } from "../../../_types/rentPost";
+
+interface PostBasicInfoProps {
+  id : number;
+  post: RentPostDetailResponseDto;
+}
+
+const PostBasicInfo: React.FC<PostBasicInfoProps> = ({ id, post }) => {
+  return (
+    <div className="bg-gray-50 rounded-lg p-4">
+      <h3 className="text-lg font-medium text-gray-900 mb-3">기본 정보</h3>
+      <div className="grid grid-cols-2 md:grid-cols-3 gap-3 text-sm">
+        <div>
+          <label className="block font-medium text-gray-700 mb-1">
+            글 ID
+          </label>
+          <p className="text-gray-900">{id}</p>
+        </div>
+        <div>
+          <label className="block font-medium text-gray-700 mb-1">
+            작성자명
+          </label>
+          <p className="text-gray-900">{post.name}</p>
+        </div>
+        <div>
+          <label className="block font-medium text-gray-700 mb-1">카테고리</label>
+          <p className="text-gray-900">{post.category}</p>
+        </div>
+        <div className="col-span-2 md:col-span-3">
+          <label className="block font-medium text-gray-700 mb-1">도서명</label>
+          <p className="text-gray-900 font-medium">
+            {post.title}
+          </p>
+        </div>
+        <div>
+          <label className="block font-medium text-gray-700 mb-1">저자</label>
+          <p className="text-gray-900">{post.author}</p>
+        </div>
+        <div>
+          <label className="block font-medium text-gray-700 mb-1">출판사</label>
+          <p className="text-gray-900">{post.publisher}</p>
+        </div>
+        <div>
+          <label className="block font-medium text-gray-700 mb-1">대여 주소</label>
+          <p className="text-gray-900">{post.address}</p>
+        </div>
+        <div className="col-span-2 md:col-span-3">
+          <label className="block font-medium text-gray-700 mb-1">내용</label>
+          <p className="text-gray-900 whitespace-pre-wrap">{post.contents}</p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PostBasicInfo;

--- a/frontend/src/app/admin/dashboard/_components/post/manage/postDetailModal.tsx
+++ b/frontend/src/app/admin/dashboard/_components/post/manage/postDetailModal.tsx
@@ -1,0 +1,220 @@
+import { useState } from "react";
+import ConfirmModal from "../../common/confirmModal";
+import PostBasicInfo from "./postBasicInfo";
+import { PostStatusInfo } from "./postStatusInfo";
+import PostInfo from "./postInfo";
+import { getRentStatus, RentPostDetailResponseDto, rentStatus } from "@/app/admin/dashboard/_types/rentPost";
+import apiClient from "@/app/bookbook/user/utils/apiClient";
+
+interface PostDetailModalProps {
+  postId: number;
+  post: RentPostDetailResponseDto;
+  isOpen: boolean;
+  onClose: () => void;
+  onRefresh?: () => void;
+  onUserDetailClick: (userId: number) => void;
+}
+
+const PostDetailModal: React.FC<PostDetailModalProps> = ({
+  postId,
+  post,
+  isOpen,
+  onClose,
+  onRefresh,
+  onUserDetailClick,
+}) => {
+  const [showConfirmModal, setShowConfirmModal] = useState(false);
+  const [confirmAction, setConfirmAction] = useState<"delete" | "updateStatus" | null>(null);
+  const [newStatus, setNewStatus] = useState<string>("");
+  const initialRentStatus = post.rentStatus;
+  const [rentStatusValue, setRentStatusValue] = useState<rentStatus>(initialRentStatus);
+  const isSameStatus = initialRentStatus == rentStatusValue;
+
+  const rentStatusButtonClassName = isSameStatus ?
+      "px-4 py-2 text-sm font-medium text-white bg-gray-600 border border-transparent rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition-colors"
+      : "px-4 py-2 text-sm font-medium text-white bg-blue-600 border border-transparent rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition-colors"
+
+  if (!isOpen || !post) return null;
+
+  const handleDeleteClick = () => {
+    setConfirmAction("delete");
+    setShowConfirmModal(true);
+  };
+
+  const handleStatusUpdate = (status: string) => {
+    setNewStatus(status);
+    setConfirmAction("updateStatus");
+    setShowConfirmModal(true);
+  };
+
+  const handleUserDetailClick = () => {
+    onUserDetailClick(post.lenderUserId);
+  }
+
+  const handlePostChangeStatus = async () => {
+    const body = {
+      "status" : rentStatusValue
+    }
+
+    apiClient(`/api/v1/admin/rent/${postId}`, {
+      method: "PATCH",
+      body: JSON.stringify(body),
+    }).then(data => {
+      alert("글 상태가 수정되었습니다.");
+    }).catch(error => {
+      throw error;
+    })
+  }
+
+  const handlePostDelete =  async () => {
+    await apiClient(`/bookbook/rent/${postId}`, {method: "DELETE"})
+        .then(data => {
+            alert(`${postId} 번 글이 성공적으로 삭제되었습니다`);
+            _onClose();
+        }).catch(error => {
+          throw error;
+    })
+  }
+
+  const _onClose = () => {
+    onClose();
+    onRefresh?.();
+  }
+
+  const handleConfirmAction = async () => {
+    try {
+      if (confirmAction === "delete") {
+        await handlePostDelete();
+      } else if (confirmAction === "updateStatus") {
+        await handlePostChangeStatus();
+      }
+
+      resetModalState();
+
+    } catch (error) {
+      console.error("처리 중 오류 발생:", error);
+      alert(`처리 중 오류가 발생했습니다. ${error.message}`);
+    }
+  };
+
+  const handleCancelAction = () => {
+    setShowConfirmModal(false);
+    setConfirmAction(null);
+    setNewStatus("");
+  };
+
+  const resetModalState = () => {
+    setShowConfirmModal(false);
+    setConfirmAction(null);
+    setNewStatus("");
+  };
+
+  const getConfirmMessage = (): string => {
+    if (confirmAction === "delete") {
+      return `정말로 ${postId}번 글을 삭제하시겠습니까?`;
+
+    } else if (confirmAction === "updateStatus") {
+      return `정말로 글 상태를 변경하시겠습니까?\n
+      ${getRentStatus(initialRentStatus)} → ${getRentStatus(rentStatusValue)}`;
+    }
+    return "";
+  };
+
+  return (
+    <>
+      <div className="fixed inset-0 z-50 flex items-center justify-center">
+        {/* 배경 오버레이 */}
+        <div
+          className="absolute inset-0 bg-black/30 backdrop-blur-sm"
+          onClick={onClose}
+        />
+
+        {/* 모달 컨텐츠 */}
+        <div className="relative bg-white rounded-lg shadow-xl max-w-2xl w-full mx-4 max-h-[90vh] overflow-y-auto">
+          {/* 헤더 */}
+          <div className="flex items-center justify-between p-6 border-b">
+            <h2 className="text-xl font-semibold text-gray-900">
+              글 상세 정보
+            </h2>
+            <button
+              onClick={_onClose}
+              className="text-gray-400 hover:text-gray-600 transition-colors"
+            >
+              <svg
+                className="w-6 h-6"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              </svg>
+            </button>
+          </div>
+
+          {/* 본문 */}
+          <div className="p-6 space-y-4">
+            <PostBasicInfo id={postId} post={post} />
+            <PostStatusInfo
+                post={post}
+                initialRentStatus={initialRentStatus}
+                setRentStatusValue={setRentStatusValue}
+            />
+            <PostInfo post={post} />
+          </div>
+
+          {/* 푸터 */}
+          <div className="flex items-center justify-between p-4 border-t bg-gray-50">
+            {/* 작성자 정보 버튼 */}
+            <button
+              onClick={handleUserDetailClick}
+              className="px-4 py-2 text-sm font-medium text-blue-700 bg-blue-50 border border-blue-200 rounded-md hover:bg-blue-100 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition-colors"
+            >
+              작성자 정보 보기
+            </button>
+            
+            {/* 관리 버튼들 */}
+            <div className="flex items-center space-x-3">
+              <button
+                onClick={_onClose}
+                className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition-colors"
+              >
+                닫기
+              </button>
+              <button
+                onClick={() => handleStatusUpdate("상태변경")}
+                disabled={initialRentStatus == rentStatusValue}
+                className={rentStatusButtonClassName}
+              >
+                상태 변경
+              </button>
+              <button
+                onClick={() => {handleDeleteClick()}}
+                className="px-4 py-2 text-sm font-medium text-white bg-red-600 border border-transparent rounded-md hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 transition-colors"
+              >
+                글 삭제
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* 확인 모달 */}
+      {showConfirmModal && (
+        <ConfirmModal
+          message={getConfirmMessage()}
+          confirmText={confirmAction === "delete" ? "삭제" : "변경"}
+          cancelText="취소"
+          onConfirm={handleConfirmAction}
+          onCancel={handleCancelAction}
+        />
+      )}
+    </>
+  );
+};
+
+export default PostDetailModal;

--- a/frontend/src/app/admin/dashboard/_components/post/manage/postDetailWithUserModal.tsx
+++ b/frontend/src/app/admin/dashboard/_components/post/manage/postDetailWithUserModal.tsx
@@ -1,0 +1,73 @@
+import { useState } from "react";
+import PostDetailModal from "./postDetailModal";
+import UserDetailModal from "../../user/manage/userDetailModal";
+import { RentPostDetailResponseDto } from "@/app/admin/dashboard/_types/rentPost";
+import { UserDetailResponseDto } from "@/app/admin/dashboard/_types/userResponseDto";
+import apiClient from "@/app/bookbook/user/utils/apiClient";
+
+interface PostDetailWithUserModalProps {
+  id: number;
+  post: RentPostDetailResponseDto;
+  isOpen: boolean;
+  onClose: () => void;
+  onRefresh?: () => void;
+}
+
+const PostDetailWithUserModal: React.FC<PostDetailWithUserModalProps> = ({
+   id,
+   post,
+   isOpen,
+   onClose,
+   onRefresh,
+ }) => {
+  const [userDetailOpen, setUserDetailOpen] = useState(false);
+  const [userDetail, setUserDetail] = useState<UserDetailResponseDto>(
+      null as unknown as UserDetailResponseDto
+  );
+
+  const handleUserDetailClick = async (userId: number) => {
+    try {
+      apiClient(`/api/v1/admin/users/${post.lenderUserId}`, {
+        method: "GET",
+      }).then((data) => {
+        console.log(data);
+        setUserDetail(data.data as UserDetailResponseDto);
+        setUserDetailOpen(true);
+      });
+
+      console.log("Fetching user detail for ID:", userId);
+
+    } catch (error) {
+      console.error("사용자 정보 조회 실패:", error);
+      alert("사용자 정보를 불러오는데 실패했습니다.");
+    }
+  };
+
+  const handleUserDetailClose = () => {
+    setUserDetailOpen(false);
+    setUserDetail(null as unknown as UserDetailResponseDto);
+  };
+
+  return (
+      <>
+        <PostDetailModal
+            postId={id}
+            post={post}
+            isOpen={isOpen || !userDetailOpen}
+            onClose={onClose}
+            onRefresh={onRefresh}
+            onUserDetailClick={handleUserDetailClick}
+        />
+
+        {userDetail && (
+            <UserDetailModal
+                user={userDetail}
+                isOpen={userDetailOpen}
+                onClose={handleUserDetailClose}
+            />
+        )}
+      </>
+  );
+};
+
+export default PostDetailWithUserModal;

--- a/frontend/src/app/admin/dashboard/_components/post/manage/postInfo.tsx
+++ b/frontend/src/app/admin/dashboard/_components/post/manage/postInfo.tsx
@@ -1,0 +1,34 @@
+import { RentPostDetailResponseDto } from "../../../_types/rentPost";
+import { formatDate } from "../../common/dateFormatter";
+
+interface PostJoinInfoProps {
+  post: RentPostDetailResponseDto;
+}
+
+const PostInfo: React.FC<PostJoinInfoProps> = ({ post }) => {
+  return (
+    <div className="bg-gray-50 rounded-lg p-4">
+      <h3 className="text-lg font-medium text-gray-900 mb-3">작성 정보</h3>
+      <div className="grid grid-cols-2 gap-3 text-sm">
+        <div>
+          <label className="block font-medium text-gray-700 mb-1">
+            작성일시
+          </label>
+          <p className="text-gray-900">
+            {formatDate(post.createdDate)}
+          </p>
+        </div>
+        <div>
+          <label className="block font-medium text-gray-700 mb-1">
+            최종 수정일시
+          </label>
+          <p className="text-gray-900">
+            {formatDate(post.modifiedDate)}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PostInfo;

--- a/frontend/src/app/admin/dashboard/_components/post/manage/postStatusInfo.tsx
+++ b/frontend/src/app/admin/dashboard/_components/post/manage/postStatusInfo.tsx
@@ -1,0 +1,56 @@
+import {
+  RentPostDetailResponseDto,
+  getRentStatus,
+  rentStatus,
+} from "../../../_types/rentPost";
+
+interface PostStatusInfoProps {
+  initialRentStatus: rentStatus
+  setRentStatusValue: (value: rentStatus) => void;
+  post: RentPostDetailResponseDto;
+}
+
+export function PostStatusInfo({ initialRentStatus, setRentStatusValue, post } : PostStatusInfoProps){
+  const getStatusColor = (status: rentStatus) => {
+    switch (status) {
+      case "AVAILABLE":
+        return "text-green-600 bg-green-50";
+      case "LOANED":
+        return "text-yellow-600 bg-yellow-50";
+      case "FINISHED":
+        return "text-gray-600 bg-gray-50";
+      default:
+        return "text-gray-600 bg-gray-50";
+    }
+  };
+
+  return (
+      <div className="bg-gray-50 rounded-lg p-4">
+        <h3 className="text-lg font-medium text-gray-900 mb-3">상태 정보</h3>
+        <div className="grid grid-cols-3 gap-3 text-sm">
+          <div>
+            <label className="block font-medium text-gray-700 mb-1">
+              대여 상태:
+              <span className={`px-1 ${getStatusColor(initialRentStatus)}`}>{getRentStatus(initialRentStatus)}</span>
+            </label>
+            <select
+                defaultValue=""
+                onChange={(e) => setRentStatusValue(e.target.value as rentStatus)}
+                className="p-3 border border-gray-300 rounded-md bg-white text-gray-900 appearance-none cursor-pointer"
+            >
+              <option value="" disabled>변경할 상태 선택</option>
+              <option value="AVAILABLE">대여 가능</option>
+              <option value="LOANED">대여 중</option>
+              <option value="FINISHED">대여 종료</option>
+            </select>
+          </div>
+          <div>
+            <label className="block font-medium text-gray-700 mb-1">도서 상태</label>
+            <p className="text-gray-900 text-sm">
+              {post.bookCondition}
+            </p>
+          </div>
+        </div>
+      </div>
+  );
+}

--- a/frontend/src/app/admin/dashboard/_components/user/filter/index.ts
+++ b/frontend/src/app/admin/dashboard/_components/user/filter/index.ts
@@ -1,3 +1,3 @@
 export { UserStatusFilter } from './userStatusFilter';
-export { UserSearchBox, type SearchType } from './userSearchBox';
+export { UserSearchBox } from './userSearchBox';
 export { UserFilterContainer, type FilterState } from './userFilterContainer';

--- a/frontend/src/app/admin/dashboard/_components/user/manage/userBasicInfo.tsx
+++ b/frontend/src/app/admin/dashboard/_components/user/manage/userBasicInfo.tsx
@@ -21,15 +21,19 @@ const UserBasicInfo: React.FC<UserBasicInfoProps> = ({ user }) => {
           </label>
           <p className="text-gray-900">{user.baseResponseDto.username}</p>
         </div>
-        <div>
+        <div className="col-span-2 md:col-span-2">
           <label className="block font-medium text-gray-700 mb-1">닉네임</label>
           <p className="text-gray-900 font-medium">
             {user.baseResponseDto.nickname}
           </p>
         </div>
-        <div className="col-span-2 md:col-span-3">
+        <div>
           <label className="block font-medium text-gray-700 mb-1">역할</label>
           <p className="text-gray-900">{getUserRole(user.baseResponseDto.role)}</p>
+        </div>
+        <div className="col-span-2 md:col-span-3">
+          <label className="block font-medium text-gray-700 mb-1">이메일</label>
+          <p className="text-gray-900">{user.baseResponseDto.email}</p>
         </div>
         <div className="col-span-2 md:col-span-3">
           <label className="block font-medium text-gray-700 mb-1">주소</label>

--- a/frontend/src/app/admin/dashboard/_hooks/useDashboard.tsx
+++ b/frontend/src/app/admin/dashboard/_hooks/useDashboard.tsx
@@ -3,6 +3,7 @@
 import {createContext, use, useCallback, useEffect, useState} from "react";
 import { MenuItem } from "@/app/admin/dashboard/_types/menuItem";
 import { menuItems } from "@/app/admin/dashboard/_components/sidebar/consts";
+import ApiClient from "@/app/bookbook/user/utils/apiClient";
 
 export default function useDashboard() {
     const [activeItem, setActiveItem] = useState('dashboard');
@@ -14,23 +15,8 @@ export default function useDashboard() {
     const fetchData = useCallback((apiPath: string) => {
         setError(false);
         setLoading(true);
-        const baseUrl = "http://localhost:8080";
 
-        fetch(baseUrl + apiPath, {
-            method: "GET",
-            headers: {
-                "Content-Type": "application/json; charset=utf-8",
-            },
-            credentials: "include",
-        })
-            .then(response => {
-                if (!response.ok) {
-                    setResponseData(null);
-                    return;
-                }
-                return response.json();
-            })
-            .then(data => {
+        ApiClient(apiPath, { method: "GET" }).then(data => {
                 if (data) {
                     console.log('데이터 새로고침:', data);
                     setResponseData(data.data);

--- a/frontend/src/app/admin/dashboard/_types/rentPost.ts
+++ b/frontend/src/app/admin/dashboard/_types/rentPost.ts
@@ -1,11 +1,39 @@
-export interface RentPost {
-  id: number;
-  lenderId: number;
+export type rentStatus = "AVAILABLE" | "LOANED" | "FINISHED";
+// export type rentStatus = "대여 가능" | "대여 중" | "대여 완료";
+
+export const getRentStatus = (status: rentStatus): string => {
+  const map: Record<rentStatus, string> = {
+    AVAILABLE: "대여 가능",
+    LOANED: "대여 중",
+    FINISHED: "대여 종료"
+  }
+  return map[status];
+}
+
+export interface RentPostDetailResponseDto {
+  lenderUserId: number;
+  bookCondition: string;
+  bookImage: string;
+  address: string;
+  contents: string;
+  rentStatus : rentStatus;
   name: string;
   title: string;
   author: string;
   publisher: string;
-  rentStatus: string;
+  category: string;
+  createdDate: string;
+  modifiedDate: string;
+}
+
+export interface RentPostSimpleResponseDto {
+  id: number;
+  lenderUserId: number;
+  status: rentStatus;
+  bookCondition: string;
+  bookTitle: string;
+  author: string;
+  publisher: string;
   createdDate: string;
   modifiedDate: string;
 }

--- a/frontend/src/app/admin/dashboard/_types/userResponseDto.ts
+++ b/frontend/src/app/admin/dashboard/_types/userResponseDto.ts
@@ -32,8 +32,9 @@ export interface UserDetailResponseDto {
 
 export interface UserBaseResponseDto {
   id: number;
-  username: string;
-  nickname: string;
+  username?: string | "";
+  nickname?: string | "";
+  email?: string | "";
   rating: number;
   createdAt: string;
   updatedAt: string;

--- a/frontend/src/app/admin/global/hooks/useAuth.tsx
+++ b/frontend/src/app/admin/global/hooks/useAuth.tsx
@@ -1,13 +1,18 @@
 import { createContext, use, useEffect, useState } from "react";
 import {userRole, userStatus} from "@/app/admin/dashboard/_types/userResponseDto";
+import apiClient from "@/app/bookbook/user/utils/apiClient";
 
 export interface UserLoginResponseDto {
     id: number;
     username: string;
-    nickname: string;
+    email?: string;
+    nickname?: string;
+    address?: string;
+    rating?: number;
     role: userRole;
-    status: userStatus;
-    avatar?: string;
+    userStatus: userStatus;
+    createAt: string;
+    registrationCompleted: boolean;
 }
 
 export default function useAuth() {
@@ -21,18 +26,13 @@ export default function useAuth() {
 
     useEffect(() => {
         const checkAuthStatus = () => {
-            fetch("http://localhost:8080/api/v1/admin/me", {
+            apiClient<UserLoginResponseDto>("/api/v1/admin/me", { // todo: api/v1/bookbook/users로 시도
                 method: "GET",
-                credentials: "include",
-            })
-            .then(response => response.json())
-            .then(data => {
+            }).then(data => {
                 setLoginMember(data.data);
-            })
-            .catch(error => {
+            }).catch(error => {
                 console.log("Auth Check Failure : ", error);
-            })
-            .finally(() => {
+            }).finally(() => {
                 setIsInitialized(true);
             })
         };
@@ -45,17 +45,13 @@ export default function useAuth() {
     };
 
     const logout = (onSuccess: () => void) => {
-        fetch("http://localhost:8080/api/v1/admin/logout", {
+        apiClient("/api/v1/admin/logout", {
             method: "DELETE",
-            credentials: "include",
-        })
-        .then((res) => res.json())
-        .then((data) => {
-            if (data.error) {
-                alert(data.error.msg);
+        }).then((data) => {
+            if (data) {
+                alert(data.msg);
                 return;
             }
-
             clearLoginMember();
             onSuccess();
         })

--- a/frontend/src/app/admin/login/page.tsx
+++ b/frontend/src/app/admin/login/page.tsx
@@ -3,8 +3,9 @@
 import { useState } from "react";
 import { Lock, User, Eye, EyeOff, BookOpen, AlertTriangle } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useAuthContext } from "@/app/admin/global/hooks/useAuth";
+import { useAuthContext, UserLoginResponseDto } from "@/app/admin/global/hooks/useAuth";
 import { UnauthorizedModal } from "../adminGuard";
+import apiClient from "@/app/bookbook/user/utils/apiClient";
 
 export default function AdminLoginPage() {
     const { setLoginMember } = useAuthContext();
@@ -46,15 +47,10 @@ export default function AdminLoginPage() {
         }
 
         // TODO: 실제 로그인 API 연동
-        fetch("http://localhost:8080/api/v1/admin/login", {
+        apiClient<UserLoginResponseDto>("/api/v1/admin/login", {
             method: "POST",
-            headers: {
-                "Content-Type": "application/json",
-            },
             body: JSON.stringify(reqBody),
-            credentials: "include",
-        }).then((response) => response.json())
-        .then(data => {
+        }).then(data => {
             console.log(data);
             if (data.statusCode !== 200) {
                 setShowUnauthorizedModal(true);


### PR DESCRIPTION
기존에 머지가 완료된 브랜치가 전부 딸려오는 바람에 다시 PR을 제출하게 됐습니다. 죄송합니다!!

## 💡 변경 사항
- [x] 게시글 목록 조회 추가
  * 대여 상태 변경 (기존 상태와 동일하면 대여 상태 변경 버튼 비활성화) 
  * 글 삭제
  * 작성자 정보 조회 버튼으로 필요 시 정지로 이어갈 수 있도록 추가
  * 대여 상태 기반 필터, 글 작성자를 유저 닉네임으로 조회할 수 있도록 추가
 
- [x] 기타 수정
  * fetch 기반 호출 -> apiClient로 변경
  * BE - AdminController ResponseEntity 기반 호출로 변경
  * AdminService에서 어드민 역할 검증 누락으로 인한 수정
  * 어드민 대시보드 - 전체 회원 조회 시 이메일 필드가 드러나도록 수정

---
### ✅ 특이 사항
- 로컬에서는 기능을 거의 다 만들어두어 잘 작동했습니다.
  - 다만, 백엔드 쪽과 관련하여 Rent 도메인 쪽 관련해서 수정 사항이 있었는데, 이 부분은 충돌 우려로 제외했습니다.
  - 또, AdminController와 관련해서 컴파일 시 오류 에러 우려가 있어, 관련 메소드 주석 처리해두었습니다.

---

### 🔗 관련 이슈
closed #103 
#110 