### PR TITLE
Feat/166 [BE] 관리자 신고 관리 백엔드 추가

### DIFF
--- a/backend/bookbook/src/main/java/com/bookbook/domain/rent/dto/RentResponseDto.java
+++ b/backend/bookbook/src/main/java/com/bookbook/domain/rent/dto/RentResponseDto.java
@@ -1,6 +1,7 @@
 // 25.08.03 현준
 package com.bookbook.domain.rent.dto;
 
+import com.bookbook.domain.rent.entity.Rent;
 import com.bookbook.domain.rent.entity.RentStatus;
 import lombok.Builder;
 
@@ -32,4 +33,23 @@ public record RentResponseDto(
         int lenderPostCount // 글쓴이 대여글 작성 수
 
 ) {
+    public static RentResponseDto from(Rent rent) {
+        return RentResponseDto.builder()
+                .id(rent.getId())
+                .lenderUserId(rent.getLenderUserId())
+                .title(rent.getTitle())
+                .bookCondition(rent.getBookCondition())
+                .bookImage(rent.getBookImage())
+                .address(rent.getAddress())
+                .contents(rent.getContents())
+                .rentStatus(rent.getRentStatus())
+                .bookTitle(rent.getBookTitle())
+                .author(rent.getAuthor())
+                .publisher(rent.getPublisher())
+                .category(rent.getCategory())
+                .description(rent.getDescription())
+                .createdDate(rent.getCreatedDate())
+                .modifiedDate(rent.getModifiedDate())
+                .build();
+    }
 }

--- a/backend/bookbook/src/main/java/com/bookbook/domain/rent/dto/RentResponseDto.java
+++ b/backend/bookbook/src/main/java/com/bookbook/domain/rent/dto/RentResponseDto.java
@@ -1,7 +1,6 @@
 // 25.08.03 현준
 package com.bookbook.domain.rent.dto;
 
-import com.bookbook.domain.rent.entity.Rent;
 import com.bookbook.domain.rent.entity.RentStatus;
 import lombok.Builder;
 
@@ -33,23 +32,4 @@ public record RentResponseDto(
         int lenderPostCount // 글쓴이 대여글 작성 수
 
 ) {
-    public static RentResponseDto from(Rent rent) {
-        return RentResponseDto.builder()
-                .id(rent.getId())
-                .lenderUserId(rent.getLenderUserId())
-                .title(rent.getTitle())
-                .bookCondition(rent.getBookCondition())
-                .bookImage(rent.getBookImage())
-                .address(rent.getAddress())
-                .contents(rent.getContents())
-                .rentStatus(rent.getRentStatus())
-                .bookTitle(rent.getBookTitle())
-                .author(rent.getAuthor())
-                .publisher(rent.getPublisher())
-                .category(rent.getCategory())
-                .description(rent.getDescription())
-                .createdDate(rent.getCreatedDate())
-                .modifiedDate(rent.getModifiedDate())
-                .build();
-    }
 }

--- a/backend/bookbook/src/main/java/com/bookbook/domain/report/controller/ReportAdminController.java
+++ b/backend/bookbook/src/main/java/com/bookbook/domain/report/controller/ReportAdminController.java
@@ -1,0 +1,73 @@
+package com.bookbook.domain.report.controller;
+
+import com.bookbook.domain.report.dto.response.ReportDetailResponseDto;
+import com.bookbook.domain.report.dto.response.ReportSimpleResponseDto;
+import com.bookbook.domain.report.enums.ReportStatus;
+import com.bookbook.domain.report.service.ReportService;
+import com.bookbook.domain.user.dto.response.PageResponse;
+import com.bookbook.global.rsdata.RsData;
+import com.bookbook.global.security.CustomOAuth2User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/admin/reports")
+@RequiredArgsConstructor
+public class ReportAdminController {
+
+    private final ReportService reportService;
+
+    @GetMapping
+    public ResponseEntity<RsData<PageResponse<ReportSimpleResponseDto>>> getReportPage(
+            @RequestParam(defaultValue = "1") Integer page,
+            @RequestParam(defaultValue = "10") Integer size,
+            @RequestParam(required = false) List<ReportStatus> status,
+            @RequestParam(required = false) Long targetUserId
+    ) {
+        Pageable pageable = PageRequest.of(page - 1, size);
+
+        Page<ReportSimpleResponseDto> reportHistoryPage = reportService.getReportPage(pageable, status, targetUserId);
+        PageResponse<ReportSimpleResponseDto> response = PageResponse.from(reportHistoryPage, page, size);
+
+        return ResponseEntity.ok(
+                RsData.of(
+                        "200-1",
+                        "%d개의 신고글을 발견했습니다.".formatted(reportHistoryPage.getTotalElements()),
+                        response
+                )
+        );
+    }
+
+    @GetMapping("/{reportId}")
+    public ResponseEntity<RsData<ReportDetailResponseDto>> getReportDetail(
+            @PathVariable Long reportId,
+            @AuthenticationPrincipal CustomOAuth2User adminUser
+    ) {
+        ReportDetailResponseDto reportDetail = reportService.getReportDetail(reportId, adminUser.getUserId());
+
+        return ResponseEntity.ok(
+                RsData.of(
+                        "200-1",
+                        "%d번 신고글 조회 완료".formatted(reportDetail.id()),
+                        reportDetail
+                )
+        );
+    }
+
+    @PatchMapping("/{reportId}/processed")
+    public ResponseEntity<RsData<Void>> processReport(
+            @PathVariable Long reportId,
+            @AuthenticationPrincipal CustomOAuth2User adminUser
+    ) {
+        reportService.markReportAsProcessed(reportId, adminUser.getUserId());
+
+        return ResponseEntity.ok(RsData.of("200-1", "%d번 글이 정상적으로 처리되었습니다.".formatted(reportId)));
+    }
+}

--- a/backend/bookbook/src/main/java/com/bookbook/domain/report/controller/ReportAdminController.java
+++ b/backend/bookbook/src/main/java/com/bookbook/domain/report/controller/ReportAdminController.java
@@ -45,12 +45,9 @@ public class ReportAdminController {
         );
     }
 
-    @GetMapping("/{reportId}")
-    public ResponseEntity<RsData<ReportDetailResponseDto>> getReportDetail(
-            @PathVariable Long reportId,
-            @AuthenticationPrincipal CustomOAuth2User adminUser
-    ) {
-        ReportDetailResponseDto reportDetail = reportService.getReportDetail(reportId, adminUser.getUserId());
+    @GetMapping("/{reportId}/review")
+    public ResponseEntity<RsData<ReportDetailResponseDto>> getReportDetail(@PathVariable Long reportId) {
+        ReportDetailResponseDto reportDetail = reportService.getReportDetail(reportId);
 
         return ResponseEntity.ok(
                 RsData.of(
@@ -61,7 +58,7 @@ public class ReportAdminController {
         );
     }
 
-    @PatchMapping("/{reportId}/processed")
+    @PatchMapping("/{reportId}/process")
     public ResponseEntity<RsData<Void>> processReport(
             @PathVariable Long reportId,
             @AuthenticationPrincipal CustomOAuth2User adminUser

--- a/backend/bookbook/src/main/java/com/bookbook/domain/report/controller/ReportController.java
+++ b/backend/bookbook/src/main/java/com/bookbook/domain/report/controller/ReportController.java
@@ -1,6 +1,6 @@
 package com.bookbook.domain.report.controller;
 
-import com.bookbook.domain.report.dto.ReportRequestDto;
+import com.bookbook.domain.report.dto.request.ReportRequestDto;
 import com.bookbook.domain.report.service.ReportService;
 import com.bookbook.global.exception.ServiceException;
 import com.bookbook.global.rsdata.RsData;

--- a/backend/bookbook/src/main/java/com/bookbook/domain/report/dto/request/ReportRequestDto.java
+++ b/backend/bookbook/src/main/java/com/bookbook/domain/report/dto/request/ReportRequestDto.java
@@ -1,4 +1,4 @@
-package com.bookbook.domain.report.dto;
+package com.bookbook.domain.report.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;

--- a/backend/bookbook/src/main/java/com/bookbook/domain/report/dto/response/ReportDetailResponseDto.java
+++ b/backend/bookbook/src/main/java/com/bookbook/domain/report/dto/response/ReportDetailResponseDto.java
@@ -14,19 +14,23 @@ public record ReportDetailResponseDto(
         @NonNull ReportStatus status,
         @NonNull Long reporterUserId,
         @NonNull Long targetUserId,
-        @NonNull Long reviewerId,
+        Long closerId,
         @NonNull String reason,
         @NonNull LocalDateTime reportedDate,
         @NonNull LocalDateTime modifiedDate,
         @NonNull LocalDateTime reviewedDate
 ){
     public static ReportDetailResponseDto from(Report report){
+        Long closerId = report.getCloser() == null
+                ? null
+                : report.getCloser().getId();
+
         return ReportDetailResponseDto.builder()
                 .id(report.getId())
                 .status(report.getStatus())
                 .reporterUserId(report.getReporterUser().getId())
                 .targetUserId(report.getTargetUser().getId())
-                .reviewerId(report.getReviewer().getId())
+                .closerId(closerId)
                 .reason(report.getReason())
                 .reportedDate(report.getCreatedDate())
                 .modifiedDate(report.getModifiedDate())

--- a/backend/bookbook/src/main/java/com/bookbook/domain/report/dto/response/ReportDetailResponseDto.java
+++ b/backend/bookbook/src/main/java/com/bookbook/domain/report/dto/response/ReportDetailResponseDto.java
@@ -1,0 +1,38 @@
+package com.bookbook.domain.report.dto.response;
+
+
+import com.bookbook.domain.report.entity.Report;
+import com.bookbook.domain.report.enums.ReportStatus;
+import lombok.Builder;
+import lombok.NonNull;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record ReportDetailResponseDto(
+        @NonNull Long id,
+        @NonNull ReportStatus status,
+        @NonNull Long reporterUserId,
+        @NonNull Long targetUserId,
+        @NonNull Long reviewerId,
+        @NonNull String reason,
+        @NonNull LocalDateTime reportedDate,
+        @NonNull LocalDateTime modifiedDate,
+        @NonNull LocalDateTime reviewedDate
+){
+    public static ReportDetailResponseDto from(Report report){
+        return ReportDetailResponseDto.builder()
+                .id(report.getId())
+                .status(report.getStatus())
+                .reporterUserId(report.getReporterUser().getId())
+                .targetUserId(report.getTargetUser().getId())
+                .reviewerId(report.getReviewer().getId())
+                .reason(report.getReason())
+                .reportedDate(report.getCreatedDate())
+                .modifiedDate(report.getModifiedDate())
+                .reviewedDate(report.getReviewedDate())
+                .build();
+    }
+
+
+}

--- a/backend/bookbook/src/main/java/com/bookbook/domain/report/dto/response/ReportSimpleResponseDto.java
+++ b/backend/bookbook/src/main/java/com/bookbook/domain/report/dto/response/ReportSimpleResponseDto.java
@@ -14,21 +14,15 @@ public record ReportSimpleResponseDto(
         @NonNull ReportStatus status,
         @NonNull Long reporterUserId,
         @NonNull Long targetUserId,
-        @NonNull LocalDateTime createdDate,
-        Long reviewerId
+        @NonNull LocalDateTime createdDate
 ){
     public static ReportSimpleResponseDto from(Report report){
-        Long reviewerID = report.getReviewer() == null
-                ? null
-                : report.getReviewer().getId();
-
         return ReportSimpleResponseDto.builder()
                 .id(report.getId())
                 .status(report.getStatus())
                 .reporterUserId(report.getReporterUser().getId())
                 .targetUserId(report.getTargetUser().getId())
                 .createdDate(report.getCreatedDate())
-                .reviewerId(reviewerID)
                 .build();
     }
 }

--- a/backend/bookbook/src/main/java/com/bookbook/domain/report/dto/response/ReportSimpleResponseDto.java
+++ b/backend/bookbook/src/main/java/com/bookbook/domain/report/dto/response/ReportSimpleResponseDto.java
@@ -1,0 +1,34 @@
+package com.bookbook.domain.report.dto.response;
+
+
+import com.bookbook.domain.report.entity.Report;
+import com.bookbook.domain.report.enums.ReportStatus;
+import lombok.Builder;
+import lombok.NonNull;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record ReportSimpleResponseDto(
+        @NonNull Long id,
+        @NonNull ReportStatus status,
+        @NonNull Long reporterUserId,
+        @NonNull Long targetUserId,
+        @NonNull LocalDateTime createdDate,
+        Long reviewerId
+){
+    public static ReportSimpleResponseDto from(Report report){
+        Long reviewerID = report.getReviewer() == null
+                ? null
+                : report.getReviewer().getId();
+
+        return ReportSimpleResponseDto.builder()
+                .id(report.getId())
+                .status(report.getStatus())
+                .reporterUserId(report.getReporterUser().getId())
+                .targetUserId(report.getTargetUser().getId())
+                .createdDate(report.getCreatedDate())
+                .reviewerId(reviewerID)
+                .build();
+    }
+}

--- a/backend/bookbook/src/main/java/com/bookbook/domain/report/entity/Report.java
+++ b/backend/bookbook/src/main/java/com/bookbook/domain/report/entity/Report.java
@@ -28,6 +28,8 @@ public class Report extends BaseEntity {
     @LastModifiedDate
     private LocalDateTime modifiedDate;
 
+    private LocalDateTime reviewedDate;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private ReportStatus status;
@@ -40,6 +42,10 @@ public class Report extends BaseEntity {
     @JoinColumn(name = "target_user_id", nullable = false)
     private User targetUser;
 
+    @ManyToOne
+    @JoinColumn(name = "reviewer_id")
+    private User reviewer;
+
     private String reason;
 
     public Report(User reporterUser, User targetUser, String reason) {
@@ -47,5 +53,17 @@ public class Report extends BaseEntity {
         this.targetUser = targetUser;
         this.reason = reason;
         this.status = ReportStatus.PENDING;
+    }
+
+    public void markAsReviewed(User reviewer) {
+        if (status == ReportStatus.PENDING) {
+            this.status = ReportStatus.REVIEWED;
+            this.reviewer = reviewer;
+            this.reviewedDate = LocalDateTime.now();
+        }
+    }
+
+    public void markAsProcessed() {
+        this.status = ReportStatus.PROCESSED;
     }
 }

--- a/backend/bookbook/src/main/java/com/bookbook/domain/report/entity/Report.java
+++ b/backend/bookbook/src/main/java/com/bookbook/domain/report/entity/Report.java
@@ -43,8 +43,8 @@ public class Report extends BaseEntity {
     private User targetUser;
 
     @ManyToOne
-    @JoinColumn(name = "reviewer_id")
-    private User reviewer;
+    @JoinColumn(name = "closer_id")
+    private User closer;
 
     private String reason;
 
@@ -55,15 +55,15 @@ public class Report extends BaseEntity {
         this.status = ReportStatus.PENDING;
     }
 
-    public void markAsReviewed(User reviewer) {
+    public void markAsReviewed() {
         if (status == ReportStatus.PENDING) {
             this.status = ReportStatus.REVIEWED;
-            this.reviewer = reviewer;
             this.reviewedDate = LocalDateTime.now();
         }
     }
 
-    public void markAsProcessed() {
+    public void markAsProcessed(User closer) {
         this.status = ReportStatus.PROCESSED;
+        this.closer = closer;
     }
 }

--- a/backend/bookbook/src/main/java/com/bookbook/domain/report/repository/ReportRepository.java
+++ b/backend/bookbook/src/main/java/com/bookbook/domain/report/repository/ReportRepository.java
@@ -1,7 +1,25 @@
 package com.bookbook.domain.report.repository;
 
 import com.bookbook.domain.report.entity.Report;
+import com.bookbook.domain.report.enums.ReportStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface ReportRepository extends JpaRepository<Report, Long> {
+    @Query("""
+        SELECT r FROM Report r WHERE
+        (:targetId IS NULL OR r.targetUser.id = :targetId) AND
+        (:status IS NULL OR r.status IN :status)
+        ORDER BY r.createdDate DESC
+    """)
+    Page<Report> findFilteredReportHistory(
+            Pageable pageable,
+            @Param("status") List<ReportStatus> status,
+            @Param("targetId") Long targetId
+    );
 }

--- a/backend/bookbook/src/main/java/com/bookbook/domain/report/service/ReportService.java
+++ b/backend/bookbook/src/main/java/com/bookbook/domain/report/service/ReportService.java
@@ -1,13 +1,20 @@
 package com.bookbook.domain.report.service;
 
+import com.bookbook.domain.report.dto.response.ReportDetailResponseDto;
+import com.bookbook.domain.report.dto.response.ReportSimpleResponseDto;
 import com.bookbook.domain.report.entity.Report;
+import com.bookbook.domain.report.enums.ReportStatus;
 import com.bookbook.domain.report.repository.ReportRepository;
 import com.bookbook.domain.user.entity.User;
 import com.bookbook.domain.user.repository.UserRepository;
 import com.bookbook.global.exception.ServiceException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -35,5 +42,57 @@ public class ReportService {
         );
 
         reportRepository.save(report);
+    }
+
+    public Page<ReportSimpleResponseDto> getReportPage(
+            Pageable pageable,
+            List<ReportStatus> status,
+            Long targetUserId
+    ) {
+        return reportRepository
+                .findFilteredReportHistory(pageable, status, targetUserId)
+                .map(ReportSimpleResponseDto::from);
+    }
+
+    @Transactional
+    public ReportDetailResponseDto getReportDetail(Long reportId, Long adminUserId) {
+        Report report = findReportById(reportId);
+
+        User admin = findAdminById(adminUserId);
+
+        report.markAsReviewed(admin);
+
+        return ReportDetailResponseDto.from(report);
+    }
+
+    @Transactional
+    public void markReportAsProcessed(Long reportId, Long userId) {
+        Report report = findReportById(reportId);
+
+        ReportStatus status = report.getStatus();
+
+        if (status == ReportStatus.PENDING) {
+            throw new ServiceException("422-1", "해당 신고를 먼저 확인해야 합니다.");
+        }
+
+        if (!report.getReviewer().getId().equals(userId)) {
+            throw new ServiceException("403-1", "신고를 확인한 관리자가 처리해야 합니다.");
+        }
+
+        if (status == ReportStatus.PROCESSED) {
+            throw new ServiceException("409-1", "해당 신고는 이미 처리가 완료되었습니다.");
+        }
+
+        report.markAsProcessed();
+    }
+
+    private User findAdminById(Long adminId) {
+        return userRepository.findById(adminId)
+                .orElseThrow(() -> new ServiceException("404-1", "존재하지 않는 어드민 유저입니다."));
+    }
+
+    private Report findReportById(Long reportId) {
+        return reportRepository.findById(reportId)
+                .orElseThrow(() -> new ServiceException("404-1", "존재하지 않는 신고입니다."));
     }
 }

--- a/backend/bookbook/src/main/java/com/bookbook/domain/report/service/ReportService.java
+++ b/backend/bookbook/src/main/java/com/bookbook/domain/report/service/ReportService.java
@@ -55,12 +55,10 @@ public class ReportService {
     }
 
     @Transactional
-    public ReportDetailResponseDto getReportDetail(Long reportId, Long adminUserId) {
+    public ReportDetailResponseDto getReportDetail(Long reportId) {
         Report report = findReportById(reportId);
 
-        User admin = findAdminById(adminUserId);
-
-        report.markAsReviewed(admin);
+        report.markAsReviewed();
 
         return ReportDetailResponseDto.from(report);
     }
@@ -75,15 +73,13 @@ public class ReportService {
             throw new ServiceException("422-1", "해당 신고를 먼저 확인해야 합니다.");
         }
 
-        if (!report.getReviewer().getId().equals(userId)) {
-            throw new ServiceException("403-1", "신고를 확인한 관리자가 처리해야 합니다.");
-        }
-
         if (status == ReportStatus.PROCESSED) {
             throw new ServiceException("409-1", "해당 신고는 이미 처리가 완료되었습니다.");
         }
 
-        report.markAsProcessed();
+        User closerAdmin = findAdminById(userId);
+        // 신고 이슈를 닫은 사람을 표기할 수 있도록
+        report.markAsProcessed(closerAdmin);
     }
 
     private User findAdminById(Long adminId) {


### PR DESCRIPTION
### ⚠️ 읽기 전에
* #165 PR에 대한 의존성으로 인해 해당 PR 머지가 선행되어야 합니다.
* 하지만, 커밋 목록이 상당 수 겹치므로, 해당 PR 머지 이후 이 PR에 충돌이 발생하는 등 문제가 생길 가능성이 매우 높습니다.
* 해결 전까지 이 PR은 위의 이유로 Merge나 Close 하지 않습니다.
* 필요 시 제가 따로 코멘트를 하겠습니다.

---
### 💡 변경 사항
신고 관련 관리자 백엔드 구현을 진행하였습니다.

- [x] Report 엔티티에 reviewedDate, closer 필드 추가
- [x] 관리자 전용 컨트롤러 추가
- [x] 응답 객체 DTO 추가
- [x] 서비스 쪽 로직 추가

---
### ✅ 특이 사항
#### [신고 처리 로직]
* 유저가 최초로 신고하면 PENDING 상태에서 대기
  * (참고) #149 
* 대시보드에서 신고 상세 버튼을 눌러 확인 시 1회에 한해 상태는 REVIEWED로, reviewedDate도 갱신됨.
* 신고 처리 시, 확인하지 않은 신고는 처리하지 못하도록 방지 로직 추가
* 신고 처리 정상 완료 시, 상태는 PROCESSED로 변경되어, 신고 처리한 어드민 유저를 표기할 수 있도록 함.
* 향후 이미 처리된 신고는 다시 처리할 수 없도록 함.

---

### 🔗 관련 이슈
#166 