### PR TITLE
[feat] Swagger UI 접근을 위한 Security 예외 설정을 추가 및 프로젝트 문서 README.md 업데이트

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,166 @@ close #이슈번호`
 ### 6. 브랜치 정리 상세(https://www.slog.gg/p/13973)
 
 - `main` 브랜치에 머지된 feature 브랜치는 **즉시 삭제**하여 불필요한 브랜치가 쌓이는 것을 방지합니다.
+
+---
+
+## 📚 BookBook - 도서 대여 플랫폼
+
+### 🏗️ 프로젝트 개요
+BookBook은 개인 간 도서 대여를 중개하는 웹 플랫폼입니다. 사용자들이 자신의 도서를 등록하고, 다른 사용자와 대여 거래를 할 수 있는 서비스입니다.
+
+### 🛠️ 기술 스택
+
+#### Frontend
+- **Framework**: Next.js 15.4.4
+- **Language**: TypeScript 5.8.3
+- **Styling**: Tailwind CSS 4.0
+- **HTTP Client**: Axios 1.11.0
+- **UI Components**: React Icons, Lucide React, React Modal
+- **Toast**: React Toastify
+
+#### Backend
+- **Framework**: Spring Boot 3.5.4
+- **Language**: Java 21
+- **Database**: H2 (개발), MySQL (프로덕션)
+- **ORM**: Spring Data JPA
+- **Security**: Spring Security + OAuth2 + JWT
+- **Documentation**: SpringDoc OpenAPI
+- **Real-time**: WebSocket + STOMP
+- **Validation**: Spring Validation
+
+### ✨ 주요 기능
+
+#### 🔐 인증/인가 시스템
+- OAuth2 소셜 로그인 (Google, Kakao, Naver)
+- JWT 기반 인증 및 Refresh Token 관리
+- 역할 기반 접근 제어 (USER, ADMIN)
+
+#### 👤 사용자 관리
+- 회원가입/로그인/로그아웃
+- 사용자 프로필 조회 및 수정
+- 회원탈퇴 기능 (Soft Delete)
+- 사용자 정지/해제 시스템 (자동 해제 스케줄링 포함)
+
+#### 📚 도서 관리
+- 도서 등록/수정/삭제 (Soft Delete)
+- 도서 검색 및 필터링 (제목, 저자, 지역별)
+- 이미지 업로드 및 관리
+- 지역별 도서 분류
+- 도서 상태 관리 (AVAILABLE, LOANED, FINISHED, DELETED)
+
+#### 📝 대여 시스템
+- 도서 대여 요청/승인/반납
+- 대여 진행 상황 실시간 추적
+- 내가 빌린 책 목록 (RentList)
+- 내가 빌려준 책 목록 (LendList)
+- 대여 가능한 도서 목록 조회
+
+#### 💬 실시간 커뮤니케이션
+- WebSocket 기반 실시간 채팅 시스템
+- 채팅방 생성 및 관리
+- 실시간 알림 시스템 (RENT_REQUEST, RETURN_REMINDER, WISHLIST_AVAILABLE, POST_CREATED)
+- 메시지 히스토리 저장 및 조회
+
+#### ⭐ 리뷰 시스템
+- 도서 리뷰 작성/수정/삭제
+- 평점 시스템
+- 리뷰 조회 및 관리
+
+#### 📋 위시리스트
+- 관심 도서 등록/삭제 (Soft Delete)
+- 위시리스트 상태 관리
+- 위시리스트 조회
+
+#### 🚨 신고 및 모니터링
+- 사용자/게시글 신고 기능
+- 관리자 신고 처리 시스템
+- 신고 상태 관리 (PENDING, REVIEWED, PROCESSED)
+
+#### 👨‍💼 관리자 기능
+- 통합 관리자 대시보드
+- 사용자 관리 (조회, 정지, 해제)
+- 도서 게시글 관리
+- 신고 내역 처리
+- 정지된 사용자 관리 및 자동 해제
+
+### 🏃‍♂️ 실행 방법
+
+#### 환경 요구사항
+- Java 21+
+- Node.js 18+
+- MySQL 8.0+ (프로덕션)
+
+#### Backend 실행
+```bash
+cd backend/bookbook
+./gradlew bootRun
+```
+
+#### Frontend 실행
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+#### 접속 정보
+- **Frontend**: http://localhost:3000/bookbook
+- **API 문서**: http://localhost:8080/swagger-ui/index.html
+- **관리자 대시보드**: http://localhost:3000/admin/dashboard
+
+### 📁 프로젝트 구조
+
+#### Frontend
+```
+frontend/src/app/
+├── bookbook/              # 메인 서비스
+│   ├── rent/             # 도서 대여
+│   ├── user/             # 사용자 페이지
+│   │   ├── lendlist/     # 빌려준 책 목록
+│   │   ├── rentlist/     # 빌린 책 목록
+│   │   ├── wishlist/     # 위시리스트
+│   │   ├── notification/ # 알림
+│   │   └── profile/      # 프로필
+│   └── MessagePopup/     # 실시간 채팅
+├── admin/                # 관리자 페이지
+│   └── dashboard/        # 관리자 대시보드
+└── components/           # 공통 컴포넌트
+```
+
+#### Backend
+```
+backend/src/main/java/com/bookbook/
+├── domain/
+│   ├── user/             # 사용자 관리
+│   ├── rent/             # 도서 대여
+│   ├── rentBookList/     # 대여 가능한 도서 목록
+│   ├── rentList/         # 빌린 책 관리
+│   ├── lendList/         # 빌려준 책 관리
+│   ├── wishList/         # 위시리스트
+│   ├── chat/             # 실시간 채팅
+│   ├── review/           # 리뷰 시스템
+│   ├── notification/     # 알림 시스템
+│   ├── report/           # 신고 관리
+│   ├── suspend/          # 사용자 정지 관리
+│   └── home/             # 홈페이지 데이터
+└── global/               # 공통 설정 및 유틸리티
+```
+
+### 🎯 주요 특징
+- **완전한 Soft Delete**: 모든 데이터 삭제는 논리적 삭제로 처리하여 데이터 복구 가능
+- **실시간 소통**: WebSocket 기반 채팅으로 원활한 거래 진행
+- **보안 강화**: Spring Security + JWT + OAuth2로 안전한 인증 시스템
+- **자동화된 관리**: 정지된 사용자 자동 해제 등 스케줄링 기능
+- **관리자 도구**: 효율적인 플랫폼 운영을 위한 통합 관리 시스템
+- **반응형 UI**: 모바일과 데스크톱 최적화된 사용자 경험
+
+### 🔒 보안 기능
+- Spring Security 기반 인증/인가
+- JWT 토큰 및 Refresh Token 자동 갱신
+- OAuth2 소셜 로그인 연동
+- 관리자 전용 보안 설정
+- CORS 정책 및 XSS 방지
+- 입력값 검증 및 SQL Injection 방지
+
+---

--- a/backend/bookbook/src/main/java/com/bookbook/global/security/securityConfig.java
+++ b/backend/bookbook/src/main/java/com/bookbook/global/security/securityConfig.java
@@ -84,7 +84,12 @@ public class securityConfig {
                                 "/api/v1/bookbook/rent/**", // API 형태의 Rent 페이지 조회 허용 추가
                                 "/api/v1/bookbook/upload-image", // 이미지 업로드 API 경로 허용 추가
                                 "/api/v1/bookbook/searchbook", // 알라딘 책 검색 API 경로 허용 추가
-                                "/ws/**" // WebSocket 엔드포인트 허용
+                                "/ws/**", // WebSocket 엔드포인트 허용
+                                "/swagger-ui/**", // Swagger UI 접근 허용
+                                "/swagger-ui.html", // Swagger UI 메인 페이지 접근 허용
+                                "/v3/api-docs/**", // OpenAPI 문서 접근 허용
+                                "/swagger-resources/**", // Swagger 리소스 접근 허용
+                                "/webjars/**" // WebJars 접근 허용
                         ).permitAll()
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll() // OPTIONS 메서드 요청은 모든 경로에 대해 허용 (Preflight 요청)
                         .requestMatchers(HttpMethod.GET, "/api/v1/bookbook/users/me").authenticated()


### PR DESCRIPTION
## 💡 변경 사항

- [x] 프로젝트 개요 및 상세 내용을 README.md에 추가
- [x] Swagger UI 접근을 위한 Security 예외 설정을 추가

---

### ✅ 특이 사항

- 프로젝트의 기술 스택, 주요 기능, 실행 방법 등을 포함하는 상세 문서를 추가했습니다.
- SpringSecurity에서 Swagger UI에 대한 접근을 허용해서, API 명세를 쉽게 확인할 수 있도록 했습니다.
- 이제 백엔드를 재시작하면 다음 URL들로 Swagger UI에 접근할 수 있습니다:
  - http://localhost:8080/swagger-ui/index.html
  - http://localhost:8080/swagger-ui.html (리다이렉트됨)

---

### 🔗 관련 이슈
