### PR TITLE
글 상세페이지 로그인 에러 해결

### DIFF
--- a/frontend/src/app/bookbook/rent/[id]/page.tsx
+++ b/frontend/src/app/bookbook/rent/[id]/page.tsx
@@ -1,12 +1,12 @@
 // src/app/bookbook/rent/[id]/page.tsx
-// 글 목록을 보여주는 페이지
+// 글 상세를 보여주는 페이지
 //08.02 현준 수정
 
 "use client";
 
 import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation'; // useRouter는 클라이언트 컴포넌트에서 사용
-import { useCurrentUser } from '../../../hooks/useCurrentUser'; // 현재 사용자 정보를 가져오는 훅 추가
+import { useAuthCheck } from '../../../hooks/useAuthCheck'; // 로그인 체크만 하는 훅 사용
 import RentModal from '@/app/components/RentModal'; // 대여하기 팝업 모달 컴포넌트
 import UserProfileModal from "@/app/components/UserProfileModal";
 
@@ -49,8 +49,8 @@ export default function BookDetailPage({ params }: { params: Promise<{ id: strin
 
     const router = useRouter(); // 페이지 이동을 위한 useRouter 훅
     
-    // 현재 로그인한 사용자 정보를 가져옵니다
-    const { user, loading: userLoading, userId } = useCurrentUser();
+    // 현재 로그인한 사용자 정보를 가져옵니다 (자동 로그인 없음)
+    const { user, loading: userLoading, userId, isAuthenticated } = useAuthCheck();
 
     // 컴포넌트가 마운트되거나 ID가 변경될 때 책 상세 정보를 불러옵니다.
     useEffect(() => {
@@ -138,8 +138,8 @@ export default function BookDetailPage({ params }: { params: Promise<{ id: strin
         }
     };
 
-    // 로딩 중일 때 표시
-    if (loading || userLoading) {
+    // 로딩 중일 때 표시 (책 정보 로딩만 확인, 사용자 정보는 비동기로 처리)
+    if (loading) {
         return (
             <div className="min-h-screen flex items-center justify-center bg-gray-100 font-inter">
                 <p className="text-gray-700 text-lg">책 정보를 불러오는 중...</p>
@@ -251,8 +251,17 @@ export default function BookDetailPage({ params }: { params: Promise<{ id: strin
                                 <path fillRule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clipRule="evenodd" />
                             </svg>
                         </button>
-                        {/* 글 작성자인 경우에만 수정하기 버튼 표시 */}
-                        {isAuthor && (
+
+                        {/* 항상 북북톡 버튼 표시 */}
+                        <button 
+                            onClick={handleChatClick}
+                            className="px-6 py-2 rounded-lg bg-blue-500 text-white font-semibold hover:bg-blue-600 shadow-md"
+                        >
+                            북북톡
+                        </button>
+                        
+                        {/* 로그인 했고, 글 작성자인 경우 수정하기 버튼 표시 */}
+                        {isAuthor && user && (
                             <button 
                                 onClick={() => router.push(`/bookbook/rent/edit/${id}`)}
                                 className="px-10 py-2 rounded-lg bg-[#D5BAA3] text-white font-semibold hover:bg-[#C2A794] shadow-md"
@@ -260,13 +269,23 @@ export default function BookDetailPage({ params }: { params: Promise<{ id: strin
                                 수정하기
                             </button>
                         )}
-                          {/* 글 작성자가 아니거나 로그인하지 않은 경우에만 대여하기 버튼 표시 */}
-                         {!isAuthor && (
+                          {/* 로그인 했고, 글 작성자가 아닌 경우 대여하기 버튼 표시 */}
+                         {!isAuthor && user && (
                              <button 
                                  onClick={() => setIsRentModalOpen(true)}
                                  className="px-10 py-2 rounded-lg bg-[#D5BAA3] text-white font-semibold hover:bg-[#C2A794] shadow-md"
                              >
                                  대여하기
+                             </button>
+                         )}
+                         {/* 로그인하지 않은 경우 안내 메시지 */}
+                         {!user && (
+                             <button 
+                                 onClick={() => alert('로그인이 필요한 서비스입니다.')}
+                                 className="px-10 py-2 rounded-lg bg-gray-400 text-white font-semibold cursor-not-allowed"
+                                 disabled
+                             >
+                                 로그인 후 대여하기
                              </button>
                          )}                        
                     </div>

--- a/frontend/src/app/hooks/useAuthCheck.ts
+++ b/frontend/src/app/hooks/useAuthCheck.ts
@@ -1,0 +1,98 @@
+// 08.04 현준
+// 글 상세페이지를 위한 로그인 체크
+
+'use client';
+
+import { useState, useEffect } from 'react';
+import { authFetch } from '../util/authFetch'; // authFetch 유틸리티 임포트
+
+interface User {
+  id: number;
+  nickname: string;
+  address: string;
+  email: string;
+  profileImage?: string;
+}
+
+interface UseAuthCheckReturn {
+  user: User | null;
+  loading: boolean;
+  error: string | null;
+  userId: number | null;
+  isAuthenticated: boolean;
+}
+
+export function useAuthCheck(): UseAuthCheckReturn {
+  const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+
+  useEffect(() => {
+    let mounted = true;
+
+    const checkAuthStatusAndFetchUser = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+
+        // 1. 먼저 인증 상태를 확인하는 API를 호출합니다.
+        // 이 API는 JWT가 없어도 401을 반환하지 않고, 단순히 'false'를 반환합니다.
+        const authStatusResponse = await fetch('http://localhost:8080/api/v1/bookbook/users/isAuthenticated', {
+            credentials: 'include',
+        });
+        
+        if (!mounted) return;
+
+        if (authStatusResponse.ok) {
+            const authStatusData = await authStatusResponse.json();
+            const isAuth = authStatusData.data;
+            setIsAuthenticated(isAuth);
+
+            if (isAuth) {
+                // 2. 인증된 경우에만 'me' API를 호출하여 사용자 정보를 가져옵니다.
+                const userResponse = await authFetch('/api/v1/bookbook/users/me');
+                if (!mounted) return;
+                
+                if (userResponse.ok) {
+                    const userData = await userResponse.json();
+                    if (userData && userData.data) {
+                        setUser(userData.data);
+                    }
+                }
+            } else {
+                // 인증되지 않은 경우
+                setUser(null);
+            }
+        } else {
+            // isAuthenticated API 호출 자체가 실패한 경우 (서버 오류 등)
+            throw new Error('인증 상태를 확인하는 데 실패했습니다.');
+        }
+      } catch (err: any) {
+        if (!mounted) return;
+        console.error('인증 상태 확인 또는 사용자 정보 조회 실패:', err);
+        setError(err.message || '사용자 정보를 불러오는 데 실패했습니다.');
+        setUser(null);
+        setIsAuthenticated(false);
+      } finally {
+        if (mounted) {
+          setLoading(false);
+        }
+      }
+    };
+
+    checkAuthStatusAndFetchUser();
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  return {
+    user,
+    loading,
+    error,
+    userId: user?.id || null,
+    isAuthenticated,
+  };
+}


### PR DESCRIPTION
## 💡 변경 사항

// 예시

- [x] 로그인 하지 않고, 글 상세페이지 진입 시 에러나는 것을 해결하였습니다.

---

### ✅ 특이 사항

- 원래 로그인 체크를 위해 사용하던 useCurrentUser.ts 훅 대신
- useAuthCheck.ts 라는 새로운 훅을 하나 더 만들었습니다.

**모든 버튼(찜, 북북톡, 대여하기) 기능을, 비 로그인 시 작동 불가능 하게 할 예정입니다.** 
**바뀐 로직상, 어쩔 수 없는 구현 부분 입니다. 로그인 시에만 사용 가능합니다.**

(로그인, 비 로그인에 따라 대여하기, 수정하기 버튼이 다르게 보이는 것은 여전히 유효 합니다.)

---

### 🔗 관련 이슈
