### PR TITLE
 [feat] 게시글 상세 페이지 찜 기능 관련 기능 개선

### DIFF
--- a/backend/bookbook/src/main/java/com/bookbook/domain/rent/controller/RentController.java
+++ b/backend/bookbook/src/main/java/com/bookbook/domain/rent/controller/RentController.java
@@ -33,8 +33,13 @@ public class RentController {
     // Rent 페이지 조회 Get요청
     @GetMapping("/{id}") // /rent/{id} 경로로 GET 요청을 처리
     @Operation(summary = " Rent 페이지 단건 조회")
-    public RentResponseDto getRentPage(@PathVariable int id){ // 경로 변수로 전달된 id를 사용, 글 id
-        return rentService.getRentPage(id);
+    public RentResponseDto getRentPage(
+            @PathVariable int id, // 경로 변수로 전달된 id를 사용, 글 id
+            @AuthenticationPrincipal CustomOAuth2User customOAuth2User
+    ){ 
+        // 인증된 사용자 ID 가져오기 (비로그인 사용자는 null)
+        Long currentUserId = customOAuth2User != null ? customOAuth2User.getUserId() : null;
+        return rentService.getRentPage(id, currentUserId);
     }
 
     // Rent 페이지 수정 Put 요청

--- a/backend/bookbook/src/main/java/com/bookbook/domain/rent/dto/RentResponseDto.java
+++ b/backend/bookbook/src/main/java/com/bookbook/domain/rent/dto/RentResponseDto.java
@@ -29,7 +29,10 @@ public record RentResponseDto(
         // 글쓴이 조회를 위해 필드 추가
         String nickname, // 글쓴이 닉네임
         Float rating, // 글쓴이 평점
-        int lenderPostCount // 글쓴이 대여글 작성 수
+        int lenderPostCount, // 글쓴이 대여글 작성 수
+        
+        // 찜 상태 확인을 위한 필드 추가
+        boolean isWishlisted // 현재 사용자의 찜 상태
 
 ) {
 }

--- a/frontend/src/app/bookbook/rent/[id]/page.tsx
+++ b/frontend/src/app/bookbook/rent/[id]/page.tsx
@@ -325,21 +325,39 @@ export default function BookDetailPage({ params }: { params: Promise<{ id: strin
 
                         {/* 로그인 했고, 글 작성자가 아닌경우에만만 찜 버튼 */}
                         {user && !isAuthor && (
-                            <button className="w-10 h-10 flex items-center justify-center rounded-lg border border-gray-400 bg-gray-50 hover:bg-gray-100 shadow-sm"
-                                // onClick={} 찜 버튼 클릭 로직이 들어갈 부분
+                            <button 
+                                onClick={handleWishlistToggle}
+                                disabled={wishlistLoading}
+                                className={`w-10 h-10 flex items-center justify-center rounded-lg border shadow-sm transition-colors ${
+                                    isWishlisted 
+                                        ? 'border-red-400 bg-red-50 hover:bg-red-100' 
+                                        : 'border-gray-400 bg-gray-50 hover:bg-gray-100'
+                                } ${wishlistLoading ? 'opacity-50 cursor-not-allowed' : ''}`}
+                                title={isWishlisted ? '찜 해제' : '찜하기'}
                             >
-                                <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-gray-500" viewBox="0 0 20 20" fill="currentColor">
-                                    <path fillRule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clipRule="evenodd" />
-                                </svg>
+                                {wishlistLoading ? (
+                                    <svg className="animate-spin h-5 w-5 text-gray-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                                        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                                        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                                    </svg>
+                                ) : (
+                                    <svg xmlns="http://www.w3.org/2000/svg" className={`h-5 w-5 ${
+                                        isWishlisted ? 'text-red-500' : 'text-gray-500'
+                                    }`} viewBox="0 0 20 20" fill={isWishlisted ? "currentColor" : "none"} stroke="currentColor" strokeWidth="2">
+                                        <path fillRule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clipRule="evenodd" />
+                                    </svg>
+                                )}
                             </button>
                         )}
 
                         {/* 로그인 하지 않았을 때, 찜 버튼 */}
                         {!user && !isAuthor &&(
-                            <button className="w-10 h-10 flex items-center justify-center rounded-lg border border-gray-400 bg-gray-50 hover:bg-gray-100 shadow-sm"
+                            <button 
+                                className="w-10 h-10 flex items-center justify-center rounded-lg border border-gray-300 bg-gray-100 cursor-not-allowed shadow-sm"
                                 onClick={() => alert('로그인이 필요한 서비스입니다.')}
+                                title="로그인이 필요합니다"
                             >
-                                <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-gray-500" viewBox="0 0 20 20" fill="currentColor">
+                                <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-gray-400" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="2">
                                     <path fillRule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clipRule="evenodd" />
                                 </svg>
                             </button>

--- a/frontend/src/app/bookbook/user/wishlist/WishListCard.tsx
+++ b/frontend/src/app/bookbook/user/wishlist/WishListCard.tsx
@@ -90,7 +90,7 @@ export default function WishListCard({ item, onRemove }: WishListCardProps) {
                             <button
                                 onClick={(e) => {
                                     e.stopPropagation();
-                                    onRemove(item.id);
+                                    onRemove(item.rentId);
                                 }}
                                 className="text-red-500 hover:text-red-700 transition-colors"
                                 title="찜 해제"

--- a/frontend/src/app/bookbook/user/wishlist/WishListCard.tsx
+++ b/frontend/src/app/bookbook/user/wishlist/WishListCard.tsx
@@ -11,18 +11,24 @@ interface WishListCardProps {
 
 export default function WishListCard({ item, onRemove }: WishListCardProps) {
     const router = useRouter();
+    
+    // 이미지 URL 처리
+    const backendBaseUrl = 'http://localhost:8080';
+    const defaultCoverImageUrl = 'https://i.postimg.cc/pLC9D2vW/noimg.gif';
+    const displayImageUrl = item.bookImage 
+        ? (item.bookImage.startsWith('http') ? item.bookImage : `${backendBaseUrl}${item.bookImage}`)
+        : defaultCoverImageUrl;
 
     const getStatusColor = (status: string) => {
         switch (status) {
-            case 'Available':
-            case '대여가능':
+            case 'AVAILABLE':
                 return 'bg-green-100 text-green-800';
-            case 'Loaned':
-            case '대출중':
+            case 'LOANED':
                 return 'bg-blue-100 text-blue-800';
-            case 'Finished':
-            case '대여불가':
+            case 'FINISHED':
                 return 'bg-gray-100 text-gray-800';
+            case 'DELETED':
+                return 'bg-red-100 text-red-800';
             default:
                 return 'bg-gray-100 text-gray-800';
         }
@@ -30,12 +36,14 @@ export default function WishListCard({ item, onRemove }: WishListCardProps) {
 
     const getStatusText = (status: string) => {
         switch (status) {
-            case 'Available':
+            case 'AVAILABLE':
                 return '대여가능';
-            case 'Loaned':
-                return '대출중';
-            case 'Finished':
-                return '대출불가';
+            case 'LOANED':
+                return '대여중';
+            case 'FINISHED':
+                return '대여불가';
+            case 'DELETED':
+                return '삭제됨';
             default:
                 return status;
         }
@@ -50,12 +58,12 @@ export default function WishListCard({ item, onRemove }: WishListCardProps) {
                 {/* 책 이미지 */}
                 <div className="flex-shrink-0">
                     <img
-                        src={item.bookImage || "/book-placeholder.png"}
+                        src={displayImageUrl}
                         alt={item.bookTitle}
                         className="w-20 h-28 object-cover rounded border border-gray-200"
                         onError={(e) => {
                             const target = e.target as HTMLImageElement;
-                            target.src = "/book-placeholder.png";
+                            target.src = defaultCoverImageUrl;
                         }}
                     />
                 </div>
@@ -71,8 +79,8 @@ export default function WishListCard({ item, onRemove }: WishListCardProps) {
                                 <p className="text-base font-medium text-gray-800">
                                     {item.bookTitle}
                                 </p>
-                                <p className="text-sm text-gray-600">저자: {item.bookAuthor}</p>
-                                <p className="text-sm text-gray-600">출판사: {item.bookPublisher}</p>
+                                <p className="text-sm text-gray-600">저자: {item.author}</p>
+                                <p className="text-sm text-gray-600">출판사: {item.publisher}</p>
                                 <p className="text-sm text-gray-600">상태: {item.bookCondition}</p>
                             </div>
                         </div>

--- a/frontend/src/app/bookbook/user/wishlist/types.ts
+++ b/frontend/src/app/bookbook/user/wishlist/types.ts
@@ -1,16 +1,14 @@
 export interface WishListItem {
     id: number;
     rentId: number;
+    title: string;
     bookTitle: string;
-    bookAuthor: string;
-    bookPublisher: string;
+    author: string;
+    publisher: string;
     bookCondition: string;
     rentStatus: string;
-    lenderUserId: number;
-    lenderUserName: string;
-    lenderNickname?: string;
     bookImage: string;
+    address: string;
+    lenderNickname: string;
     createDate: string;
-    title?: string;
-    address?: string;
 }


### PR DESCRIPTION
## 💡 변경 사항

- [x] BookDetail 타입에 isWishlisted 속성을 추가하여 책의 찜 상태를 관리
- [x] useEffect 내 API 호출 시 찜 상태를 함께 불러와 초기 상태를 설정
- [x] handleWishlistToggle 함수를 추가하여 찜하기/찜 해제 API를 연동
- [x] 찜하기 버튼을 추가하고, 찜 상태에 따라 버튼의 스타일(색상, 아이콘)과 기능을 동적으로 변경
- [x] 로그인이 필요한 서비스임을 알리는 alert 메시지와 버튼 비활성화 처리를 추가

---

### ✅ 특이 사항

- 코드에서 특별히 설명해야 할 부분 (주석 등으로 드러나지 않는 부분)
- 코드 리뷰를 특별히 요청하고 싶은 부분

---

### 🔗 관련 이슈

